### PR TITLE
Feat: admin dashboard phase 2 — Articles CRUD

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,19 +28,19 @@ Replace the `madmin` gem with a custom `Dashboard::` namespace that lives fully 
 
 ---
 
-### Phase 1 — Dashboard skeleton
+### ~~Phase 1 — Dashboard skeleton~~
 
-- Create `Dashboard::BaseController < ApplicationController` with `before_action :admin_only!`
-- Create a `dashboard#index` landing page
-- Rewrite `config/routes/madmin.rb` → `config/routes/dashboard.rb` with the same constraint pointing at the `Dashboard::` namespace
-- Keep the `/admin` path so no URLs change
+- ~~Create `Dashboard::BaseController < ApplicationController` with `before_action :admin_only!`~~
+- ~~Create a `dashboard#index` landing page~~
+- ~~Rewrite `config/routes/madmin.rb` → `config/routes/dashboard.rb` with the same constraint pointing at the `Dashboard::` namespace~~
+- ~~Keep the `/admin` path so no URLs change~~
 
-### Phase 2 — Articles CRUD
+### ~~Phase 2 — Articles CRUD~~
 
-- `Dashboard::ArticlesController` — full CRUD
-- Render the existing `articles/_form.html.erb` partial directly (Bootstrap, works out of the box)
-- `create` always sets `user = Current.user` (guaranteed admin — no fallback needed)
-- Port the 8-line custom create action from `Madmin::ArticlesController`
+- ~~`Dashboard::ArticlesController` — full CRUD~~
+- ~~Render the existing `articles/_form.html.erb` partial directly (Bootstrap, works out of the box)~~
+- ~~`create` always sets `user = Current.user` (guaranteed admin — no fallback needed)~~
+- ~~Port the 8-line custom create action from `Madmin::ArticlesController`~~
 
 ### Phase 3 — Users
 
@@ -86,8 +86,8 @@ Once all phases are complete and tests pass:
 
 | Phase | Complexity | Notes |
 |---|---|---|
-| 1 — Skeleton + routes | Low | ~30 min |
-| 2 — Articles | Medium | Form reuse makes this fast |
+| ~~1 — Skeleton + routes~~ | ~~Low~~ | ~~~30 min~~ |
+| ~~2 — Articles~~ | ~~Medium~~ | ~~Form reuse makes this fast~~ |
 | 3 — Users | Low | Simple form |
 | 4 — Tags | Low | Simplest CRUD |
 | 5 — Sessions | Low | Read-only |

--- a/app/controllers/dashboard/articles_controller.rb
+++ b/app/controllers/dashboard/articles_controller.rb
@@ -1,0 +1,66 @@
+module Dashboard
+  class ArticlesController < Dashboard::BaseController
+    before_action :set_article, only: %i[show edit update destroy]
+
+    def index
+      @pagy, @articles = pagy(Article.includes(:tags).order(Arel.sql("COALESCE(published_at, created_at) DESC")))
+    end
+
+    def show
+    end
+
+    def new
+      @article = Article.new
+    end
+
+    def edit
+    end
+
+    def create
+      @article = Article.new(article_params)
+      @article.user = Current.user
+
+      if @article.save
+        redirect_to dashboard_article_path(@article), notice: "Article was successfully created."
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def update
+      notices = []
+
+      if @article.update(article_params)
+        notices << "Article was successfully updated."
+
+        if params.dig(:article, :remove_image).present? && params.dig(:article, :image).blank?
+          if @article.image.attached?
+            @article.image.purge
+            notices << "Image removed."
+          else
+            notices << "No image was attached to remove."
+          end
+        end
+
+        redirect_to dashboard_article_path(@article), notice: notices.join(" "), status: :see_other
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @article.destroy!
+      redirect_to dashboard_articles_path, notice: "Article was successfully deleted.", status: :see_other
+    end
+
+    private
+
+    def set_article
+      @article = Article.friendly.find(params.require(:id))
+    end
+
+    def article_params
+      params.require(:article).permit(:title, :content, :published_at, :is_published, :image, :remove_image, tag_ids: [])
+    end
+  end
+end

--- a/app/views/dashboard/_sidebar.html.erb
+++ b/app/views/dashboard/_sidebar.html.erb
@@ -9,7 +9,7 @@
       <% end %>
     </li>
     <li class="nav-item">
-      <%= link_to "Articles", "#",
+      <%= link_to "Articles", dashboard_articles_path,
             class: "nav-link rounded #{controller_path == 'dashboard/articles' ? 'active fw-semibold' : 'text-body'}" %>
     </li>
     <li class="nav-item">

--- a/app/views/dashboard/articles/_form.html.erb
+++ b/app/views/dashboard/articles/_form.html.erb
@@ -1,0 +1,83 @@
+<%= form_with model: [:dashboard, article], html: { multipart: true } do |form| %>
+  <%= render "shared/form_errors", object: article %>
+
+  <div class="mb-3">
+    <%= form.label :title, class: "form-label" %>
+    <%= form.text_field :title, class: "form-control" %>
+  </div>
+
+  <div class="mb-3">
+    <%= form.label :tag_ids, "Tags", class: "form-label" %>
+    <%= form.collection_select :tag_ids, Tag.ordered, :id, :display_name,
+          {},
+          { multiple: true, class: "form-select", data: { controller: "tom-select" } } %>
+    <div class="form-text">Type to search existing tags or create a new one by typing and pressing Enter.</div>
+  </div>
+
+  <div class="row mb-3">
+    <div class="col-auto d-flex align-items-center">
+      <div class="form-check">
+        <%= form.check_box :is_published, class: "form-check-input" %>
+        <%= form.label :is_published, class: "form-check-label ms-1" %>
+      </div>
+    </div>
+    <div class="col-auto">
+      <%= form.label :published_at, "Published date", class: "form-label" %>
+      <%= form.date_field :published_at, class: "form-control" %>
+    </div>
+  </div>
+
+  <div class="mb-3">
+    <%= form.label :image, class: "form-label" %>
+
+    <div data-controller="image-picker"
+         data-image-picker-direct-upload-url-value="<%= rails_direct_uploads_url %>">
+
+      <%= form.hidden_field :image,
+            id: "article_image_signed_id",
+            disabled: true,
+            data: { "image-picker-target": "signedId" } %>
+
+      <div class="d-flex align-items-start gap-2">
+        <div class="flex-grow-1">
+          <div class="input-group">
+            <button type="button" class="btn btn-outline-secondary"
+                    data-action="click->image-picker#openModal"
+                    data-image-picker-target="chooseButton">
+              <%= article.image.attached? ? "Change Image" : "Choose Image" %>
+            </button>
+            <input type="text" readonly class="form-control"
+                   data-image-picker-target="filename"
+                   aria-label="Selected image"
+                   value="<%= article.image.attached? ? article.image.filename.to_s : "No image selected" %>">
+          </div>
+          <div class="form-text">Choose from your image library or upload a new one. JPEG, PNG, WEBP or GIF, max 5 MB.</div>
+        </div>
+
+        <div class="flex-shrink-0">
+          <% if article.persisted? %>
+            <%= render "articles/image_preview", article: article %>
+          <% else %>
+            <img src="" alt="preview" class="article-thumb d-none" data-image-picker-target="preview">
+          <% end %>
+        </div>
+      </div>
+
+      <%= render "articles/image_picker_modal" %>
+    </div>
+  </div>
+
+  <div class="mb-4">
+    <%= form.label :content, class: "form-label" %>
+    <%= form.lexxy_rich_text_area :content %>
+  </div>
+
+  <div class="d-flex gap-2">
+    <%= form.submit class: "btn btn-primary" %>
+    <% if article.persisted? %>
+      <%= link_to "Cancel", dashboard_article_path(article), class: "btn btn-link" %>
+    <% else %>
+      <%= link_to "Cancel", dashboard_articles_path, class: "btn btn-link" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/dashboard/articles/edit.html.erb
+++ b/app/views/dashboard/articles/edit.html.erb
@@ -1,0 +1,12 @@
+<%= content_for :title, "Edit Article" %>
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0">Edit Article</h1>
+  <%= link_to "← Articles", dashboard_articles_path, class: "btn btn-sm btn-outline-secondary" %>
+</div>
+
+<div class="card shadow-sm">
+  <div class="card-body p-4">
+    <%= render "form", article: @article %>
+  </div>
+</div>

--- a/app/views/dashboard/articles/index.html.erb
+++ b/app/views/dashboard/articles/index.html.erb
@@ -53,6 +53,8 @@
   <p class="text-muted text-center mt-4">No articles yet. <%= link_to "Create one", new_dashboard_article_path %>.</p>
 <% end %>
 
-<div class="mt-3">
-  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
-</div>
+<% if @pagy.pages > 1 %>
+  <div class="mt-3 d-flex justify-content-center">
+    <%== @pagy.bootstrap_series_nav %>
+  </div>
+<% end %>

--- a/app/views/dashboard/articles/index.html.erb
+++ b/app/views/dashboard/articles/index.html.erb
@@ -55,6 +55,6 @@
 
 <% if @pagy.pages > 1 %>
   <div class="mt-3 d-flex justify-content-center">
-    <%== @pagy.bootstrap_series_nav %>
+    <%== @pagy.series_nav(:bootstrap) %>
   </div>
 <% end %>

--- a/app/views/dashboard/articles/index.html.erb
+++ b/app/views/dashboard/articles/index.html.erb
@@ -1,0 +1,58 @@
+<%= content_for :title, "Articles" %>
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0">Articles</h1>
+  <%= link_to "New Article", new_dashboard_article_path, class: "btn btn-primary btn-sm" %>
+</div>
+
+<div class="card shadow-sm">
+  <div class="table-responsive">
+    <table class="table table-hover align-middle mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>Title</th>
+          <th>Tags</th>
+          <th>Status</th>
+          <th>Date</th>
+          <th class="text-end">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @articles.each do |article| %>
+          <tr>
+            <td class="fw-medium"><%= article.title %></td>
+            <td>
+              <% article.tags.each do |tag| %>
+                <span class="badge text-bg-secondary me-1"><%= tag.display_name %></span>
+              <% end %>
+            </td>
+            <td>
+              <% if article.is_published? %>
+                <span class="badge text-bg-success">Published</span>
+              <% else %>
+                <span class="badge text-bg-warning text-dark">Draft</span>
+              <% end %>
+            </td>
+            <td class="text-muted small">
+              <%= (article.published_at || article.created_at).strftime("%b %-d, %Y") %>
+            </td>
+            <td class="text-end">
+              <%= link_to "Edit", edit_dashboard_article_path(article), class: "btn btn-sm btn-outline-secondary me-1" %>
+              <%= button_to "Delete", dashboard_article_path(article), method: :delete,
+                    data: { turbo_confirm: "Delete \"#{article.title}\"?" },
+                    class: "btn btn-sm btn-outline-danger" %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<% if @articles.empty? %>
+  <p class="text-muted text-center mt-4">No articles yet. <%= link_to "Create one", new_dashboard_article_path %>.</p>
+<% end %>
+
+<div class="mt-3">
+  <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
+</div>

--- a/app/views/dashboard/articles/new.html.erb
+++ b/app/views/dashboard/articles/new.html.erb
@@ -1,0 +1,12 @@
+<%= content_for :title, "New Article" %>
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0">New Article</h1>
+  <%= link_to "← Articles", dashboard_articles_path, class: "btn btn-sm btn-outline-secondary" %>
+</div>
+
+<div class="card shadow-sm">
+  <div class="card-body p-4">
+    <%= render "form", article: @article %>
+  </div>
+</div>

--- a/app/views/dashboard/articles/show.html.erb
+++ b/app/views/dashboard/articles/show.html.erb
@@ -1,0 +1,62 @@
+<%= content_for :title, @article.title %>
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0"><%= @article.title %></h1>
+  <div class="d-flex gap-2">
+    <%= link_to "Edit", edit_dashboard_article_path(@article), class: "btn btn-sm btn-primary" %>
+    <%= button_to "Delete", dashboard_article_path(@article), method: :delete,
+          data: { turbo_confirm: "Delete \"#{@article.title}\"?" },
+          class: "btn btn-sm btn-outline-danger" %>
+    <%= link_to "← Articles", dashboard_articles_path, class: "btn btn-sm btn-outline-secondary" %>
+  </div>
+</div>
+
+<div class="row g-3">
+  <div class="col-md-8">
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <div class="lexxy-content" data-controller="code-highlight">
+          <%= @article.content %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-4">
+    <div class="card shadow-sm mb-3">
+      <div class="card-body">
+        <h6 class="card-title text-muted small text-uppercase mb-3">Details</h6>
+        <dl class="row mb-0 small">
+          <dt class="col-5 text-muted">Status</dt>
+          <dd class="col-7">
+            <% if @article.is_published? %>
+              <span class="badge text-bg-success">Published</span>
+            <% else %>
+              <span class="badge text-bg-warning text-dark">Draft</span>
+            <% end %>
+          </dd>
+          <dt class="col-5 text-muted">Published</dt>
+          <dd class="col-7"><%= @article.published_at&.strftime("%b %-d, %Y") || "—" %></dd>
+          <dt class="col-5 text-muted">Created</dt>
+          <dd class="col-7"><%= @article.created_at.strftime("%b %-d, %Y") %></dd>
+          <dt class="col-5 text-muted">Tags</dt>
+          <dd class="col-7">
+            <% @article.tags.each do |tag| %>
+              <span class="badge text-bg-secondary me-1"><%= tag.display_name %></span>
+            <% end %>
+          </dd>
+        </dl>
+      </div>
+    </div>
+
+    <% if @article.image.attached? %>
+      <div class="card shadow-sm">
+        <div class="card-body text-center">
+          <h6 class="card-title text-muted small text-uppercase mb-3">Cover Image</h6>
+          <%= image_tag @article.image.variant(resize_to_limit: [400, 300]),
+                class: "img-fluid rounded", alt: @article.title %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/dashboard/dashboard/index.html.erb
+++ b/app/views/dashboard/dashboard/index.html.erb
@@ -8,7 +8,7 @@
       <div class="card-body">
         <div class="text-muted small mb-1">Total Articles</div>
         <div class="fs-3 fw-semibold"><%= @article_count %></div>
-        <%= link_to "View all", "#", class: "stretched-link text-decoration-none small" %>
+        <%= link_to "View all", dashboard_articles_path, class: "stretched-link text-decoration-none small" %>
       </div>
     </div>
   </div>
@@ -18,7 +18,7 @@
       <div class="card-body">
         <div class="text-muted small mb-1">Published</div>
         <div class="fs-3 fw-semibold"><%= @published_count %></div>
-        <%= link_to "View all", "#", class: "stretched-link text-decoration-none small" %>
+        <%= link_to "View all", dashboard_articles_path, class: "stretched-link text-decoration-none small" %>
       </div>
     </div>
   </div>
@@ -46,6 +46,6 @@
 
 <h2 class="h5 mb-3">Quick actions</h2>
 <div class="d-flex gap-2">
-  <%= link_to "New Article", "#", class: "btn btn-primary" %>
+  <%= link_to "New Article", new_dashboard_article_path, class: "btn btn-primary" %>
   <%= link_to "New Tag",     "#", class: "btn btn-outline-secondary" %>
 </div>

--- a/spec/requests/dashboard/articles_spec.rb
+++ b/spec/requests/dashboard/articles_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+RSpec.describe "Dashboard::Articles", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:article) { create(:article, user: admin) }
+
+  let(:valid_params) do
+    tag = create(:tag)
+    {
+      title: "Dashboard Article",
+      content: "Body text.",
+      is_published: true,
+      published_at: Time.current.to_s,
+      tag_ids: [tag.id],
+      image: Rack::Test::UploadedFile.new(
+        Rails.root.join("spec", "fixtures", "files", "test_image.jpg"),
+        "image/jpeg"
+      )
+    }
+  end
+
+  let(:invalid_params) { { title: "", content: "" } }
+
+  context "when unauthenticated" do
+    it "returns 404 for all actions (route constraint)" do
+      get dashboard_articles_path
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context "when authenticated as admin" do
+    before { sign_in_as(admin) }
+
+    describe "GET /admin/articles" do
+      it "returns 200" do
+        article
+        get dashboard_articles_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "GET /admin/articles/:id" do
+      it "returns 200" do
+        get dashboard_article_path(article)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "GET /admin/articles/new" do
+      it "returns 200" do
+        get new_dashboard_article_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "GET /admin/articles/:id/edit" do
+      it "returns 200" do
+        get edit_dashboard_article_path(article)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "POST /admin/articles" do
+      it "creates article assigned to the current admin" do
+        expect {
+          post dashboard_articles_path, params: { article: valid_params }
+        }.to change(Article, :count).by(1)
+        expect(Article.last.user).to eq(admin)
+      end
+
+      it "redirects to the dashboard show page on success" do
+        post dashboard_articles_path, params: { article: valid_params }
+        expect(response).to redirect_to(dashboard_article_path(Article.last))
+      end
+
+      it "renders new with 422 on invalid params" do
+        post dashboard_articles_path, params: { article: invalid_params }
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    describe "PATCH /admin/articles/:id" do
+      it "updates the article and redirects to dashboard show" do
+        patch dashboard_article_path(article), params: { article: { title: "Updated" } }
+        expect(article.reload.title).to eq("Updated")
+        expect(response).to redirect_to(dashboard_article_path(article))
+      end
+
+      it "renders edit with 422 on invalid params" do
+        patch dashboard_article_path(article), params: { article: { title: "" } }
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    describe "DELETE /admin/articles/:id" do
+      it "destroys the article and redirects to dashboard index" do
+        article
+        expect {
+          delete dashboard_article_path(article)
+        }.to change(Article, :count).by(-1)
+        expect(response).to redirect_to(dashboard_articles_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `Dashboard::ArticlesController` — full CRUD (index, show, new, create, edit, update, destroy)
- Dashboard-namespaced form using `model: [:dashboard, article]` so routes generate correctly at `/admin/articles`
- `create` always assigns `Current.user` (guaranteed admin, no fallback needed)
- `update` handles `remove_image` param inline
- Index table shows all articles (published + drafts) with status badges, tags, date, and actions
- Show page with article detail, metadata sidebar, and cover image
- Pagination via `@pagy.series_nav(:bootstrap)` (Pagy v43 object-method API)
- Sidebar Articles link and landing page cards wired up
- ROADMAP phases 1 and 2 struck through
- 11 new request specs; 171 total, 0 failures

## Test plan

- [ ] `bin/cleanup` — all green
- [ ] `/admin/articles` lists all articles with Published/Draft badges
- [ ] New article form works — image picker, Trix editor, tag selector
- [ ] Edit article saves correctly and redirects to dashboard show
- [ ] Delete article redirects to dashboard index
- [ ] Pagination appears when > 5 articles

🤖 Generated with [Claude Code](https://claude.com/claude-code)