### PR TITLE
feat: admin article index enhancements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -471,6 +471,8 @@ GEM
     turbo-rails (2.0.23)
       actionpack (>= 7.1.0)
       railties (>= 7.1.0)
+    turbo_rspec (1.6.0)
+      nokogiri (>= 1.13)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
@@ -549,6 +551,7 @@ DEPENDENCIES
   test-prof
   thruster
   turbo-rails
+  turbo_rspec
   tzinfo-data
   web-console
   webmock

--- a/app/controllers/dashboard/articles_controller.rb
+++ b/app/controllers/dashboard/articles_controller.rb
@@ -5,7 +5,10 @@ module Dashboard
     def index
       @sort      = %w[title date status].include?(params[:sort]) ? params[:sort] : "date"
       @direction = params[:direction] == "asc" ? "asc" : "desc"
-      @pagy, @articles = pagy(Article.includes(:tags).sorted(@sort, @direction))
+      @query     = params[:q].to_s.strip
+      scope      = Article.includes(:tags)
+      scope      = scope.where("articles.title LIKE ?", "%#{@query}%") if @query.present?
+      @pagy, @articles = pagy(scope.sorted(@sort, @direction))
     end
 
     def show

--- a/app/controllers/dashboard/articles_controller.rb
+++ b/app/controllers/dashboard/articles_controller.rb
@@ -3,7 +3,7 @@ module Dashboard
     before_action :set_article, only: %i[show edit update destroy]
 
     def index
-      @sort      = %w[title date tags].include?(params[:sort]) ? params[:sort] : "date"
+      @sort      = %w[title date status].include?(params[:sort]) ? params[:sort] : "date"
       @direction = params[:direction] == "asc" ? "asc" : "desc"
       @pagy, @articles = pagy(Article.includes(:tags).sorted(@sort, @direction))
     end

--- a/app/controllers/dashboard/articles_controller.rb
+++ b/app/controllers/dashboard/articles_controller.rb
@@ -2,19 +2,10 @@ module Dashboard
   class ArticlesController < Dashboard::BaseController
     before_action :set_article, only: %i[show edit update destroy]
 
-    SORT_ORDERS = {
-      ["title", "asc"] => Arel.sql("articles.title ASC"),
-      ["title", "desc"] => Arel.sql("articles.title DESC"),
-      ["date",  "asc"] => Arel.sql("COALESCE(articles.published_at, articles.created_at) ASC"),
-      ["date",  "desc"] => Arel.sql("COALESCE(articles.published_at, articles.created_at) DESC"),
-      ["tags",  "asc"] => Arel.sql("(SELECT MIN(tags.name) FROM tags INNER JOIN article_tags ON article_tags.tag_id = tags.id WHERE article_tags.article_id = articles.id) ASC"),
-      ["tags",  "desc"] => Arel.sql("(SELECT MIN(tags.name) FROM tags INNER JOIN article_tags ON article_tags.tag_id = tags.id WHERE article_tags.article_id = articles.id) DESC")
-    }.freeze
-
     def index
-      @sort      = SORT_ORDERS.key?([params[:sort], "asc"]) ? params[:sort] : "date"
+      @sort      = %w[title date tags].include?(params[:sort]) ? params[:sort] : "date"
       @direction = params[:direction] == "asc" ? "asc" : "desc"
-      @pagy, @articles = pagy(Article.includes(:tags).order(SORT_ORDERS[[@sort, @direction]]))
+      @pagy, @articles = pagy(Article.includes(:tags).sorted(@sort, @direction))
     end
 
     def show

--- a/app/controllers/dashboard/articles_controller.rb
+++ b/app/controllers/dashboard/articles_controller.rb
@@ -2,8 +2,19 @@ module Dashboard
   class ArticlesController < Dashboard::BaseController
     before_action :set_article, only: %i[show edit update destroy]
 
+    SORT_ORDERS = {
+      ["title", "asc"] => Arel.sql("articles.title ASC"),
+      ["title", "desc"] => Arel.sql("articles.title DESC"),
+      ["date",  "asc"] => Arel.sql("COALESCE(articles.published_at, articles.created_at) ASC"),
+      ["date",  "desc"] => Arel.sql("COALESCE(articles.published_at, articles.created_at) DESC"),
+      ["tags",  "asc"] => Arel.sql("(SELECT MIN(tags.name) FROM tags INNER JOIN article_tags ON article_tags.tag_id = tags.id WHERE article_tags.article_id = articles.id) ASC"),
+      ["tags",  "desc"] => Arel.sql("(SELECT MIN(tags.name) FROM tags INNER JOIN article_tags ON article_tags.tag_id = tags.id WHERE article_tags.article_id = articles.id) DESC")
+    }.freeze
+
     def index
-      @pagy, @articles = pagy(Article.includes(:tags).order(Arel.sql("COALESCE(published_at, created_at) DESC")))
+      @sort      = SORT_ORDERS.key?([params[:sort], "asc"]) ? params[:sort] : "date"
+      @direction = params[:direction] == "asc" ? "asc" : "desc"
+      @pagy, @articles = pagy(Article.includes(:tags).order(SORT_ORDERS[[@sort, @direction]]))
     end
 
     def show

--- a/app/controllers/dashboard/articles_controller.rb
+++ b/app/controllers/dashboard/articles_controller.rb
@@ -50,7 +50,10 @@ module Dashboard
 
     def destroy
       @article.destroy!
-      redirect_to dashboard_articles_path, notice: "Article was successfully deleted.", status: :see_other
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.remove(ActionView::RecordIdentifier.dom_id(@article)) }
+        format.html { redirect_to dashboard_articles_path, notice: "Article was successfully deleted.", status: :see_other }
+      end
     end
 
     private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,6 +27,16 @@ module ApplicationHelper
       .presence || "Application"
   end
 
+  def sort_direction(column)
+    return "asc" unless @sort == column.to_s
+    @direction == "asc" ? "desc" : "asc"
+  end
+
+  def sort_indicator(column)
+    return "" unless @sort == column.to_s
+    @direction == "asc" ? " ↑" : " ↓"
+  end
+
   # Generates a preview of article content from ActionText rich text
   def article_preview(content, length: 50)
     return "" if content.blank?

--- a/app/javascript/controllers/article_search_controller.js
+++ b/app/javascript/controllers/article_search_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input"]
+
+  search() {
+    clearTimeout(this.debounceTimer)
+    const length = this.inputTarget.value.length
+    if (length >= 4 || length === 0) {
+      this.debounceTimer = setTimeout(() => this.element.requestSubmit(), 300)
+    }
+  }
+
+  disconnect() {
+    clearTimeout(this.debounceTimer)
+  }
+}

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -35,8 +35,8 @@ class Article < ApplicationRecord
     when ["title", "desc"] then order(Arel.sql("articles.title DESC"))
     when ["date",  "asc"]  then order(Arel.sql("COALESCE(articles.published_at, articles.created_at) ASC"))
     when ["date",  "desc"] then order(Arel.sql("COALESCE(articles.published_at, articles.created_at) DESC"))
-    when ["tags",  "asc"]  then order(Arel.sql("(SELECT MIN(tags.name) FROM tags INNER JOIN article_tags ON article_tags.tag_id = tags.id WHERE article_tags.article_id = articles.id) ASC"))
-    when ["tags",  "desc"] then order(Arel.sql("(SELECT MIN(tags.name) FROM tags INNER JOIN article_tags ON article_tags.tag_id = tags.id WHERE article_tags.article_id = articles.id) DESC"))
+    when ["status", "asc"]  then order(Arel.sql("articles.is_published ASC"))
+    when ["status", "desc"] then order(Arel.sql("articles.is_published DESC"))
     else recent
     end
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -29,6 +29,18 @@ class Article < ApplicationRecord
   before_save :autoset_published_at, if: -> { will_save_change_to_is_published? }
 
 
+  def self.sorted(column, direction)
+    case [column, direction]
+    when ["title", "asc"]  then order(Arel.sql("articles.title ASC"))
+    when ["title", "desc"] then order(Arel.sql("articles.title DESC"))
+    when ["date",  "asc"]  then order(Arel.sql("COALESCE(articles.published_at, articles.created_at) ASC"))
+    when ["date",  "desc"] then order(Arel.sql("COALESCE(articles.published_at, articles.created_at) DESC"))
+    when ["tags",  "asc"]  then order(Arel.sql("(SELECT MIN(tags.name) FROM tags INNER JOIN article_tags ON article_tags.tag_id = tags.id WHERE article_tags.article_id = articles.id) ASC"))
+    when ["tags",  "desc"] then order(Arel.sql("(SELECT MIN(tags.name) FROM tags INNER JOIN article_tags ON article_tags.tag_id = tags.id WHERE article_tags.article_id = articles.id) DESC"))
+    else recent
+    end
+  end
+
   def self.visible_to(user)
     if user&.admin?
       all.recent

--- a/app/views/dashboard/articles/index.html.erb
+++ b/app/views/dashboard/articles/index.html.erb
@@ -5,58 +5,60 @@
   <%= link_to "New Article", new_dashboard_article_path, class: "btn btn-primary btn-sm" %>
 </div>
 
-<div class="card shadow-sm">
-  <div class="table-responsive">
-    <table class="table table-hover align-middle mb-0">
-      <thead class="table-light">
-        <tr>
-          <th>Title</th>
-          <th>Tags</th>
-          <th>Status</th>
-          <th>Date</th>
-          <th class="text-end">Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @articles.each do |article| %>
-          <tr id="<%= dom_id(article) %>">
-            <td class="fw-medium"><%= article.title %></td>
-            <td>
-              <% article.tags.each do |tag| %>
-                <span class="badge text-bg-light me-1"><%= tag.display_name %></span>
-              <% end %>
-            </td>
-            <td>
-              <% if article.is_published? %>
-                <span class="badge text-bg-success">Published</span>
-              <% else %>
-                <span class="badge text-bg-warning text-dark">Draft</span>
-              <% end %>
-            </td>
-            <td class="text-muted small">
-              <%= (article.published_at || article.created_at).strftime("%b %-d, %Y") %>
-            </td>
-            <td>
-              <div class="d-flex gap-1 justify-content-end">
-                <%= link_to "Edit", edit_dashboard_article_path(article), class: "btn btn-sm btn-outline-secondary" %>
-                <%= button_to "Delete", dashboard_article_path(article), method: :delete,
-                      data: { turbo_confirm: "Delete \"#{article.title}\"?" },
-                      class: "btn btn-sm btn-outline-danger" %>
-              </div>
-            </td>
+<%= turbo_frame_tag "articles-table" do %>
+  <div class="card shadow-sm">
+    <div class="table-responsive">
+      <table class="table table-hover align-middle mb-0">
+        <thead class="table-light">
+          <tr>
+            <th><%= link_to "Title#{sort_indicator(:title)}".html_safe, dashboard_articles_path(sort: :title, direction: sort_direction(:title)), class: "text-decoration-none text-dark fw-semibold" %></th>
+            <th><%= link_to "Tags#{sort_indicator(:tags)}".html_safe, dashboard_articles_path(sort: :tags, direction: sort_direction(:tags)), class: "text-decoration-none text-dark fw-semibold" %></th>
+            <th>Status</th>
+            <th><%= link_to "Date#{sort_indicator(:date)}".html_safe, dashboard_articles_path(sort: :date, direction: sort_direction(:date)), class: "text-decoration-none text-dark fw-semibold" %></th>
+            <th class="text-end">Actions</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% @articles.each do |article| %>
+            <tr id="<%= dom_id(article) %>">
+              <td class="fw-medium"><%= article.title %></td>
+              <td>
+                <% article.tags.each do |tag| %>
+                  <span class="badge text-bg-light me-1"><%= tag.display_name %></span>
+                <% end %>
+              </td>
+              <td>
+                <% if article.is_published? %>
+                  <span class="badge text-bg-success">Published</span>
+                <% else %>
+                  <span class="badge text-bg-warning text-dark">Draft</span>
+                <% end %>
+              </td>
+              <td class="text-muted small">
+                <%= (article.published_at || article.created_at).strftime("%b %-d, %Y") %>
+              </td>
+              <td>
+                <div class="d-flex gap-1 justify-content-end">
+                  <%= link_to "Edit", edit_dashboard_article_path(article), class: "btn btn-sm btn-outline-secondary" %>
+                  <%= button_to "Delete", dashboard_article_path(article), method: :delete,
+                        data: { turbo_confirm: "Delete \"#{article.title}\"?" },
+                        class: "btn btn-sm btn-outline-danger" %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
-</div>
 
-<% if @articles.empty? %>
-  <p class="text-muted text-center mt-4">No articles yet. <%= link_to "Create one", new_dashboard_article_path %>.</p>
-<% end %>
+  <% if @articles.empty? %>
+    <p class="text-muted text-center mt-4">No articles yet. <%= link_to "Create one", new_dashboard_article_path %>.</p>
+  <% end %>
 
-<% if @pagy.pages > 1 %>
-  <div class="mt-3 d-flex justify-content-center">
-    <%== @pagy.series_nav(:bootstrap) %>
-  </div>
+  <% if @pagy.pages > 1 %>
+    <div class="mt-3 d-flex justify-content-center">
+      <%== @pagy.series_nav(:bootstrap) %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/dashboard/articles/index.html.erb
+++ b/app/views/dashboard/articles/index.html.erb
@@ -39,7 +39,7 @@
               </td>
               <td>
                 <div class="d-flex gap-1 justify-content-end">
-                  <%= link_to "Edit", edit_dashboard_article_path(article), class: "btn btn-sm btn-outline-secondary" %>
+                  <%= link_to "Edit", edit_dashboard_article_path(article), class: "btn btn-sm btn-outline-secondary", data: { turbo_frame: "_top" } %>
                   <%= button_to "Delete", dashboard_article_path(article), method: :delete,
                         data: { turbo_confirm: "Delete \"#{article.title}\"?" },
                         class: "btn btn-sm btn-outline-danger" %>

--- a/app/views/dashboard/articles/index.html.erb
+++ b/app/views/dashboard/articles/index.html.erb
@@ -2,7 +2,19 @@
 
 <div class="d-flex justify-content-between align-items-center mb-4">
   <h1 class="h3 mb-0">Articles</h1>
-  <%= link_to "New Article", new_dashboard_article_path, class: "btn btn-primary btn-sm" %>
+  <div class="d-flex gap-2 align-items-center">
+    <%= form_with url: dashboard_articles_path, method: :get,
+                  data: { controller: "article-search", turbo_frame: "articles-table" } do |f| %>
+      <%= f.hidden_field :sort, value: @sort %>
+      <%= f.hidden_field :direction, value: @direction %>
+      <%= f.search_field :q, value: @query,
+            placeholder: "Search titles…",
+            class: "form-control form-control-sm",
+            autocomplete: "off",
+            data: { article_search_target: "input", action: "input->article-search#search" } %>
+    <% end %>
+    <%= link_to "New Article", new_dashboard_article_path, class: "btn btn-primary btn-sm" %>
+  </div>
 </div>
 
 <%= turbo_frame_tag "articles-table" do %>
@@ -11,10 +23,10 @@
       <table class="table table-hover align-middle mb-0">
         <thead class="table-light">
           <tr>
-            <th><%= link_to "Title#{sort_indicator(:title)}".html_safe, dashboard_articles_path(sort: :title, direction: sort_direction(:title)), class: "text-decoration-none text-dark fw-semibold" %></th>
+            <th><%= link_to "Title#{sort_indicator(:title)}".html_safe, dashboard_articles_path(sort: :title, direction: sort_direction(:title), q: @query), class: "text-decoration-none text-dark fw-semibold" %></th>
             <th>Tags</th>
-            <th><%= link_to "Status#{sort_indicator(:status)}".html_safe, dashboard_articles_path(sort: :status, direction: sort_direction(:status)), class: "text-decoration-none text-dark fw-semibold" %></th>
-            <th><%= link_to "Date#{sort_indicator(:date)}".html_safe, dashboard_articles_path(sort: :date, direction: sort_direction(:date)), class: "text-decoration-none text-dark fw-semibold" %></th>
+            <th><%= link_to "Status#{sort_indicator(:status)}".html_safe, dashboard_articles_path(sort: :status, direction: sort_direction(:status), q: @query), class: "text-decoration-none text-dark fw-semibold" %></th>
+            <th><%= link_to "Date#{sort_indicator(:date)}".html_safe, dashboard_articles_path(sort: :date, direction: sort_direction(:date), q: @query), class: "text-decoration-none text-dark fw-semibold" %></th>
             <th class="text-end">Actions</th>
           </tr>
         </thead>

--- a/app/views/dashboard/articles/index.html.erb
+++ b/app/views/dashboard/articles/index.html.erb
@@ -19,7 +19,7 @@
       </thead>
       <tbody>
         <% @articles.each do |article| %>
-          <tr>
+          <tr id="<%= dom_id(article) %>">
             <td class="fw-medium"><%= article.title %></td>
             <td>
               <% article.tags.each do |tag| %>

--- a/app/views/dashboard/articles/index.html.erb
+++ b/app/views/dashboard/articles/index.html.erb
@@ -12,8 +12,8 @@
         <thead class="table-light">
           <tr>
             <th><%= link_to "Title#{sort_indicator(:title)}".html_safe, dashboard_articles_path(sort: :title, direction: sort_direction(:title)), class: "text-decoration-none text-dark fw-semibold" %></th>
-            <th><%= link_to "Tags#{sort_indicator(:tags)}".html_safe, dashboard_articles_path(sort: :tags, direction: sort_direction(:tags)), class: "text-decoration-none text-dark fw-semibold" %></th>
-            <th>Status</th>
+            <th>Tags</th>
+            <th><%= link_to "Status#{sort_indicator(:status)}".html_safe, dashboard_articles_path(sort: :status, direction: sort_direction(:status)), class: "text-decoration-none text-dark fw-semibold" %></th>
             <th><%= link_to "Date#{sort_indicator(:date)}".html_safe, dashboard_articles_path(sort: :date, direction: sort_direction(:date)), class: "text-decoration-none text-dark fw-semibold" %></th>
             <th class="text-end">Actions</th>
           </tr>

--- a/config/gems/rspec_gemfile.rb
+++ b/config/gems/rspec_gemfile.rb
@@ -12,4 +12,5 @@ group :test do
   gem 'simplecov', '~> 0.22.0', require: false
   gem 'simplecov-json', require: false
   gem "test-prof"
+  gem "turbo_rspec"
 end

--- a/config/gems/rspec_gemfile.rb
+++ b/config/gems/rspec_gemfile.rb
@@ -12,5 +12,5 @@ group :test do
   gem 'simplecov', '~> 0.22.0', require: false
   gem 'simplecov-json', require: false
   gem "test-prof"
-  gem "turbo_rspec"
+  gem "turbo_rspec", require: false
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -300,6 +300,20 @@ RSpec.describe Article, type: :model do
       expect(result.last).to eq(alpha)
     end
 
+    it "sorts by status ascending (drafts first)" do
+      published = create(:article, :published, user: user)
+      draft     = create(:article, user: user)
+      result    = Article.sorted("status", "asc").to_a
+      expect(result.index(draft)).to be < result.index(published)
+    end
+
+    it "sorts by status descending (published first)" do
+      published = create(:article, :published, user: user)
+      draft     = create(:article, user: user)
+      result    = Article.sorted("status", "desc").to_a
+      expect(result.index(published)).to be < result.index(draft)
+    end
+
     it "falls back to recent order for unrecognised column" do
       expect(Article.sorted("unknown", "asc")).to eq(Article.recent)
     end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -273,4 +273,35 @@ RSpec.describe Article, type: :model do
       expect { article.valid? }.not_to raise_error
     end
   end
+
+  describe ".sorted" do
+    let(:user)   { create(:user) }
+    let!(:alpha) { create(:article, title: "Alpha", user: user) }
+    let!(:beta)  { create(:article, title: "Beta",  user: user) }
+    let!(:gamma) { create(:article, title: "Gamma", user: user) }
+
+    it "sorts by title ascending" do
+      expect(Article.sorted("title", "asc").map(&:title)).to eq(%w[Alpha Beta Gamma])
+    end
+
+    it "sorts by title descending" do
+      expect(Article.sorted("title", "desc").map(&:title)).to eq(%w[Gamma Beta Alpha])
+    end
+
+    it "sorts by date ascending" do
+      result = Article.sorted("date", "asc").to_a
+      expect(result.first).to eq(alpha)
+      expect(result.last).to eq(gamma)
+    end
+
+    it "sorts by date descending" do
+      result = Article.sorted("date", "desc").to_a
+      expect(result.first).to eq(gamma)
+      expect(result.last).to eq(alpha)
+    end
+
+    it "falls back to recent order for unrecognised column" do
+      expect(Article.sorted("unknown", "asc")).to eq(Article.recent)
+    end
+  end
 end

--- a/spec/requests/dashboard/articles_spec.rb
+++ b/spec/requests/dashboard/articles_spec.rb
@@ -37,6 +37,28 @@ RSpec.describe "Dashboard::Articles", type: :request do
         get dashboard_articles_path
         expect(response).to have_http_status(:ok)
       end
+
+      context "with sort params" do
+        it "accepts title sort" do
+          get dashboard_articles_path(sort: "title", direction: "asc")
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "accepts tags sort" do
+          get dashboard_articles_path(sort: "tags", direction: "asc")
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "accepts date sort" do
+          get dashboard_articles_path(sort: "date", direction: "asc")
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "defaults to date desc when sort param is unrecognised" do
+          get dashboard_articles_path(sort: "injected_sql", direction: "evil")
+          expect(response).to have_http_status(:ok)
+        end
+      end
     end
 
     describe "GET /admin/articles/:id" do

--- a/spec/requests/dashboard/articles_spec.rb
+++ b/spec/requests/dashboard/articles_spec.rb
@@ -112,6 +112,16 @@ RSpec.describe "Dashboard::Articles", type: :request do
         }.to change(Article, :count).by(-1)
         expect(response).to redirect_to(dashboard_articles_path)
       end
+
+      it "responds with turbo stream that removes the row" do
+        article
+        expect {
+          delete dashboard_article_path(article), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        }.to change(Article, :count).by(-1)
+        expect(response).to have_turbo_stream
+          .with_action(:remove)
+          .targeting(ActionView::RecordIdentifier.dom_id(article))
+      end
     end
   end
 end

--- a/spec/requests/dashboard/articles_spec.rb
+++ b/spec/requests/dashboard/articles_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe "Dashboard::Articles", type: :request do
           expect(response).to have_http_status(:ok)
         end
 
-        it "accepts tags sort" do
-          get dashboard_articles_path(sort: "tags", direction: "asc")
+        it "accepts status sort" do
+          get dashboard_articles_path(sort: "status", direction: "asc")
           expect(response).to have_http_status(:ok)
         end
 

--- a/spec/support/turbo_rspec.rb
+++ b/spec/support/turbo_rspec.rb
@@ -1,0 +1,6 @@
+require "turbo_rspec"
+
+TurboRspec.configure do |config|
+  # auto_include is true by default — matchers are included into
+  # :request, :controller, :system, and :feature example groups automatically.
+end

--- a/spec/system/dashboard_article_delete_spec.rb
+++ b/spec/system/dashboard_article_delete_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Dashboard article delete", type: :system do
+  include_context "database cleanup"
+
+  let(:admin) { create(:user, :admin) }
+  let!(:article) { create(:article, user: admin) }
+
+  before(:each) do
+    driven_by(:headless_chrome)
+    visit test_sign_in_path(admin)
+    visit dashboard_articles_path
+  end
+
+  after(:all) { purge_all_records }
+
+  it "removes the row via Turbo without a full page reload" do
+    row_id = ActionView::RecordIdentifier.dom_id(article)
+
+    expect(page).to have_css("##{row_id}")
+
+    page.evaluate_script("window.confirm = function() { return true; }")
+    within("##{row_id}") { click_button "Delete" }
+
+    expect(page).not_to have_css("##{row_id}")
+    expect(page).to have_current_path(dashboard_articles_path)
+  end
+end

--- a/spec/system/dashboard_article_search_spec.rb
+++ b/spec/system/dashboard_article_search_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "Dashboard article search", type: :system do
+  include_context "database cleanup"
+
+  before(:all) do
+    purge_all_records
+    @admin = create(:user, :admin)
+    create(:article, title: "Rails Routing Guide", user: @admin)
+    create(:article, title: "Stimulus Handbook",   user: @admin)
+    create(:article, title: "Turbo Frames Deep Dive", user: @admin)
+  end
+
+  after(:all) { purge_all_records }
+
+  before(:each) do
+    driven_by(:headless_chrome)
+    visit test_sign_in_path(@admin)
+    visit dashboard_articles_path
+  end
+
+  it "has the search input wired to the article-search stimulus controller" do
+    input = find("input[name='q']")
+    expect(input["data-action"]).to include("article-search#search")
+    expect(input["data-article-search-target"]).to eq("input")
+  end
+
+  it "filters the table when the q param is present" do
+    visit dashboard_articles_path(q: "Rail")
+    expect(page).to have_css("tbody tr", count: 1)
+    expect(page).to have_text("Rails Routing Guide")
+    expect(page).not_to have_text("Stimulus Handbook")
+  end
+
+  it "shows all articles when query is blank" do
+    visit dashboard_articles_path(q: "Rail")
+    expect(page).to have_css("tbody tr", count: 1)
+
+    visit dashboard_articles_path
+    expect(page).to have_css("tbody tr", count: 3)
+  end
+
+  it "preserves the search term when sorting" do
+    visit dashboard_articles_path(q: "Rail")
+    expect(page).to have_css("tbody tr", count: 1)
+
+    click_link "Title"
+    expect(page).to have_current_path(/q=Rail/)
+    expect(page).to have_css("tbody tr", count: 1)
+  end
+end

--- a/spec/system/dashboard_article_sort_spec.rb
+++ b/spec/system/dashboard_article_sort_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "Dashboard article sort", type: :system do
+  include_context "database cleanup"
+
+  before(:all) do
+    purge_all_records
+    @admin = create(:user, :admin)
+    create(:article, title: "Alpha Article", user: @admin)
+    create(:article, title: "Beta Article",  user: @admin)
+    create(:article, title: "Gamma Article", user: @admin)
+  end
+
+  after(:all) { purge_all_records }
+
+  before(:each) do
+    driven_by(:headless_chrome)
+    visit test_sign_in_path(@admin)
+    visit dashboard_articles_path
+  end
+
+  it "sorts by title ascending without a full page reload" do
+    click_link "Title"
+
+    expect(page).to have_current_path(/sort=title/)
+    titles = all("tbody tr td.fw-medium").map(&:text)
+    expect(titles).to eq(titles.sort)
+  end
+
+  it "toggles title sort to descending on second click" do
+    click_link "Title"
+    click_link "Title"
+
+    expect(page).to have_current_path(/direction=desc/)
+    titles = all("tbody tr td.fw-medium").map(&:text)
+    expect(titles).to eq(titles.sort.reverse)
+  end
+
+  it "sorts by date without a full page reload" do
+    click_link "Date"
+
+    expect(page).to have_current_path(/sort=date/)
+    expect(page).to have_css("tbody tr")
+  end
+
+  it "sorts by tags without a full page reload" do
+    within("thead") { click_link "Tags" }
+
+    expect(page).to have_current_path(/sort=tags/)
+    expect(page).to have_css("tbody tr")
+  end
+
+  it "shows a sort indicator on the active column" do
+    click_link "Title"
+
+    within("thead") { expect(page).to have_text(/Title\s*[↑↓]/) }
+  end
+end

--- a/spec/system/dashboard_article_sort_spec.rb
+++ b/spec/system/dashboard_article_sort_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe "Dashboard article sort", type: :system do
     expect(page).to have_css("tbody tr")
   end
 
-  it "sorts by tags without a full page reload" do
-    within("thead") { click_link "Tags" }
+  it "sorts by status without a full page reload" do
+    within("thead") { click_link "Status" }
 
-    expect(page).to have_current_path(/sort=tags/)
+    expect(page).to have_current_path(/sort=status/)
     expect(page).to have_css("tbody tr")
   end
 


### PR DESCRIPTION
## Summary

- **Turbo Stream delete** — clicking Delete removes the table row in-place via `turbo_stream.remove`; no full page reload. Each `<tr>` gets a `dom_id` as its HTML id.
- **Sortable columns** — Title, Status, and Date headers are clickable sort links that update only the table via a Turbo Frame (`articles-table`). Sort SQL lives in `Article.sorted(column, direction)` (static `Arel.sql` literals, Brakeman-clean). Two `ApplicationHelper` methods (`sort_direction`, `sort_indicator`) drive the link targets and ↑/↓ arrows.
- **Live search** — search input (outside the frame, targeting it) filters articles by title via `LIKE`. The `article-search` Stimulus controller debounces the `input` event and calls `requestSubmit()` after 4+ characters or on clear. Sort links carry `q:` so search + sort compose correctly.
- **`turbo_rspec` gem** added (author's own gem) with auto-included matchers for request and system specs.
- Edit link given `data-turbo-frame="_top"` to break out of the frame correctly.

## Test plan

- [ ] Request specs: all sort params, invalid-param fallback, Turbo Stream delete response (`have_turbo_stream`)
- [ ] Model specs: `Article.sorted` for all columns and fallback
- [ ] System specs: sort asc/desc toggle, sort indicator, delete row removal, search filtering, sort-preserves-search, search Stimulus wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)