### PR TITLE
feat: Add SEO meta tags, Open Graph, Twitter Cards, and JSON-LD

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,8 @@ GEM
       net-smtp
     marcel (1.2.1)
     matrix (0.4.3)
+    meta-tags (2.23.0)
+      actionpack (>= 6.0.0)
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
@@ -534,6 +536,7 @@ DEPENDENCIES
   kamal
   letter_opener_web
   lexxy (~> 0.7.4.beta)
+  meta-tags
   openssl (~> 3.3, >= 3.3.2)
   overcommit
   pagy

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,27 @@ class ApplicationController < ActionController::Base
 
   # Changes to the importmap will invalidate the etag for HTML responses
   stale_when_importmap_changes
+
+  before_action :set_default_meta_tags
+
+  private
+
+  def set_default_meta_tags
+    set_meta_tags(
+      site:        "Eclectic Coding",
+      description: "Senior Software Engineer writing about Ruby on Rails, " \
+                   "open source, and software craftsmanship.",
+      separator:   "|",
+      og: {
+        site_name: "Eclectic Coding",
+        type:      "website",
+        locale:    "en_US"
+      },
+      twitter: {
+        card: "summary_large_image",
+        site: "@eclecticcoding"
+      },
+      canonical: request.original_url
+    )
+  end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -7,6 +7,18 @@ class ArticlesController < ApplicationController
     resume_session
     @pagy, @articles = pagy(Article.includes(:tags).visible_to(current_user))
 
+    set_meta_tags(
+      title:       "Articles",
+      description: "Articles on Ruby on Rails, open source development, and " \
+                   "software engineering by Chuck Smith.",
+      og: {
+        title: "Articles | Eclectic Coding",
+        type:  "website",
+        url:   articles_url
+      },
+      canonical:    articles_url
+    )
+
     respond_to do |format|
       format.html
       format.turbo_stream
@@ -14,6 +26,7 @@ class ArticlesController < ApplicationController
   end
 
   def show
+    set_article_meta_tags
     respond_to do |format|
       format.html
       format.md { render markdown: @article }
@@ -21,6 +34,32 @@ class ArticlesController < ApplicationController
   end
 
   private
+
+  def set_article_meta_tags
+    description = helpers.article_preview(@article.content, length: 160)
+    og_image    = @article.image.attached? ? rails_blob_url(@article.image, only_path: false) : nil
+
+    meta = {
+      title:       @article.title,
+      description: description,
+      og: {
+        title:       @article.title,
+        description: description,
+        type:        "article",
+        url:         article_url(@article)
+      },
+      twitter: {
+        title:       @article.title,
+        description: description
+      },
+      canonical:    article_url(@article)
+    }
+
+    meta[:og][:image]      = og_image if og_image
+    meta[:twitter][:image] = og_image if og_image
+
+    set_meta_tags(meta)
+  end
 
   def set_visible_article
     begin

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -4,5 +4,17 @@ class StaticController < ApplicationController
   def home
     @latest_articles = Article.published.recent.limit(5)
     @gems = RubygemsService.gems
+
+    set_meta_tags(
+      title:       "Chuck Smith — Senior Rails Engineer",
+      description: "Senior Software Engineer passionate about Ruby on Rails, " \
+                   "open source gems, and software craftsmanship.",
+      og: {
+        title: "Chuck Smith — Senior Rails Engineer",
+        type:  "website",
+        url:   root_url
+      },
+      canonical:    root_url
+    )
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -19,6 +19,12 @@ class TagsController < ApplicationController
     @tag = Tag.find_by_param(params[:id]) || raise(ActiveRecord::RecordNotFound)
     @pagy, @articles = pagy(@tag.articles.includes(:tags).visible_to(current_user))
 
+    set_meta_tags(
+      title:       "#{@tag.display_name} Articles",
+      description: "Articles tagged with #{@tag.display_name} on Eclectic Coding.",
+      canonical:    tag_url(@tag)
+    )
+
     respond_to do |format|
       format.html
       format.turbo_stream

--- a/app/views/articles/_json_ld.html.erb
+++ b/app/views/articles/_json_ld.html.erb
@@ -1,0 +1,26 @@
+<script type="application/ld+json" nonce="<%= content_security_policy_nonce %>">
+<%= json_escape({
+  "@context":        "https://schema.org",
+  "@type":           "BlogPosting",
+  "headline":        article.title,
+  "description":     article_preview(article.content, length: 160),
+  "url":             article_url(article),
+  "datePublished":   (article.published_at || article.created_at)&.iso8601,
+  "dateModified":    article.updated_at&.iso8601,
+  "author": {
+    "@type": "Person",
+    "name":  "Chuck Smith",
+    "url":   root_url
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name":  "Eclectic Coding",
+    "url":   root_url
+  },
+  "image":           article.image.attached? ? rails_blob_url(article.image, only_path: false) : nil,
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id":   article_url(article)
+  }
+}.compact.to_json.html_safe) %>
+</script>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head do %>
+  <%= render "json_ld", article: @article %>
+<% end %>
+
 <div class="row">
   <div class="col-12 col-md-8 mx-auto">
     <div class="card <%= @article.published_at.present? ? 'bg-body-tertiary border-0' : 'card-draft' %>">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="<%= locale %>" class="h-100">
   <head>
-    <title><%= content_for?(:title) ? content_for(:title) : app_title %></title>
+    <%= display_meta_tags site: "Eclectic Coding" %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="application-name" content="Rails81">
+    <meta name="application-name" content="<%= app_title %>">
     <meta name="mobile-web-app-capable" content="yes">
     <%= csp_meta_tag %>
     <%= csrf_meta_tags %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,6 +40,7 @@ Rails.application.configure do
 
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_controller.default_url_options = { host: "localhost", port: 3000 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,6 +59,7 @@ Rails.application.configure do
 
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST", "example.com") }
+  config.action_controller.default_url_options = { host: ENV.fetch("APP_HOST", "eclecticcoding.com"), protocol: "https" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,6 +39,7 @@ Rails.application.configure do
 
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_controller.default_url_options = { host: "www.example.com" }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/gems/app.rb
+++ b/config/gems/app.rb
@@ -8,6 +8,7 @@ gem "openssl", "~> 3.3", ">= 3.3.2"
 gem "pagy"
 gem "lexxy", "~> 0.7.4.beta"
 gem "friendly_id"
+gem "meta-tags"
 
 group :development, :test do
   gem "erb_lint"

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -49,5 +49,68 @@ RSpec.describe "/articles", type: :request do
       get article_url(draft)
       expect(response).to be_successful
     end
+
+    describe "SEO meta tags" do
+      let(:article) { create(:article, :published, title: "My Rails Article") }
+
+      it "sets title from article" do
+        get article_url(article)
+        expect(response.body).to match(/<title>Eclectic Coding \| My Rails Article/)
+      end
+
+      it "includes meta description" do
+        get article_url(article)
+        expect(response.body).to include('name="description"')
+      end
+
+      it "sets og:type to article" do
+        get article_url(article)
+        expect(response.body).to include('property="og:type"')
+          .and include('content="article"')
+      end
+
+      it "sets canonical to article URL" do
+        get article_url(article)
+        expect(response.body).to include('rel="canonical"')
+          .and include(article_url(article))
+      end
+
+      it "includes twitter:card" do
+        get article_url(article)
+        expect(response.body).to include('name="twitter:card"')
+          .and include('summary_large_image')
+      end
+
+      it "includes og:image" do
+        get article_url(article)
+        expect(response.body).to include('property="og:image"')
+      end
+
+      it "includes JSON-LD BlogPosting" do
+        get article_url(article)
+        expect(response.body).to include('application/ld+json')
+          .and include('"@type":"BlogPosting"')
+          .and include('"headline":"My Rails Article"')
+      end
+
+      it "escapes dangerous content in JSON-LD" do
+        danger = create(:article, :published, title: 'XSS </script><script>alert(1)</script>')
+        get article_url(danger)
+        expect(response.body).not_to include("</script><script>alert(1)")
+      end
+    end
+
+    describe "SEO meta tags for articles index" do
+      it "sets articles index title" do
+        get articles_url
+        expect(response.body).to match(/<title>Eclectic Coding \| Articles/)
+      end
+
+      it "includes canonical for articles index" do
+        get articles_url
+        expect(response.body).to include('rel="canonical"')
+          .and include(articles_url)
+      end
+    end
   end
 end

--- a/spec/requests/static_spec.rb
+++ b/spec/requests/static_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe "Statics", type: :request do
       expect(response).to have_http_status(:success)
     end
 
+    it "includes meta description on home page" do
+      get root_url
+      expect(response.body).to include('name="description"')
+    end
+
+    it "sets canonical to root URL" do
+      get root_url
+      expect(response.body).to include('rel="canonical"')
+        .and include(root_url)
+    end
+
     it "calls RubygemsService" do
       expect(RubygemsService).to receive(:gems).and_return([])
       get "/"


### PR DESCRIPTION
## Summary

- Integrates the `meta-tags` gem for full SEO coverage across all public pages
- Adds per-page title, meta description, canonical URLs, `og:*` and `twitter:*` tags via `set_meta_tags` in each controller
- Adds `schema.org` `BlogPosting` JSON-LD structured data on article show pages, using the article cover image as `og:image`
- Fixes hardcoded `application-name` meta tag (`"Rails81"` → `app_title`)
- Configures `action_controller.default_url_options` in all environments so `rails_blob_url` generates absolute URLs for OG images

## Test plan

- [x] 11 new request spec assertions covering title, description, og:type, canonical, twitter:card, og:image, JSON-LD, and XSS safety
- [x] Full suite: 275 examples, 0 failures, 100% coverage
- [x] Pre-push gate passed (rspec + brakeman + bundle-audit + rubocop)
- [ ] Manually verify OG tags on an article page with [opengraph.xyz](https://opengraph.xyz) or Twitter Card Validator after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)