### PR TITLE
feat: Project model, migration, factory, and specs (Phase 1)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,3 +1,93 @@
 # Roadmap
 
-No milestones are currently planned.
+## Projects Portfolio Feature
+
+Replace the ad-hoc `RubygemsService` display with a proper `Project` resource that supports any type of software project (RubyGems, GitHub repos, npm packages, etc.), admin-managed CRUD, and an optional daily sync for gem metadata.
+
+### Motivation
+
+The current `RubygemsService` only covers RubyGems and has no persistence — it fetches live on every page load (with caching). A persisted `Project` model gives full editorial control, supports non-gem projects, and decouples the public display from the upstream API.
+
+---
+
+### Phase 1 — Project Model & Migration
+
+Create the `projects` table with fields that cover both manually-entered and API-synced projects:
+
+| Column | Type | Notes |
+|---|---|---|
+| `name` | string | display name |
+| `description` | text | short blurb |
+| `url` | string | live project / docs URL |
+| `source_url` | string | GitHub or repo link |
+| `project_type` | string | `rubygem`, `github`, `npm`, `other` |
+| `rubygem_name` | string | gem slug used for sync (nullable) |
+| `version` | string | current release (synced or manual) |
+| `is_featured` | boolean | pin to top of public list |
+| `position` | integer | manual sort order |
+| `last_synced_at` | datetime | set by sync job |
+| `timestamps` | | standard |
+
+Validations: `name` and `url` required; `project_type` in allowlist.
+
+---
+
+### Phase 2 — Admin CRUD
+
+Add a `Admin::ProjectsController` (or route under the existing `dashboard/` namespace, matching current convention) with standard `index / new / create / edit / update / destroy` actions, gated behind `admin_only!`.
+
+- Index table shows name, type, version, last_synced_at, featured toggle
+- Form: all fields; `rubygem_name` shown only when type is `rubygem`
+- Stimulus controller to conditionally show/hide `rubygem_name` field based on `project_type` select
+- Flash notices on create/update/destroy
+
+---
+
+### Phase 3 — RubyGems Import Helper
+
+Add a one-click "Import from RubyGems" action (`POST /admin/projects/import_rubygems`) that:
+
+1. Calls `RubygemsService.gems` (existing fetch-all endpoint)
+2. For each gem not already in `projects` (matched by `rubygem_name`), upserts a `Project` row with `project_type: "rubygem"` and populated `name`, `description`, `url`, `version`
+3. Redirects to index with a summary flash ("3 gems imported, 2 already existed")
+
+This makes initial population fast without manual entry.
+
+---
+
+### Phase 4 — Daily Sync Job
+
+Create `ProjectSyncJob < ApplicationJob` that updates gem metadata for all projects where `rubygem_name` is present:
+
+1. Fetch individual gem data from `https://rubygems.org/api/v1/gems/{name}.json`
+2. Update `version`, `description`, `last_synced_at` only — never overwrite `name`, `url`, `is_featured`, or `position` (those are editorial)
+3. Silence errors per-gem (log and continue) so one bad gem doesn't abort the batch
+
+Schedule via a **Solid Queue recurring job** (Rails 8 built-in) in `config/recurring.yml`:
+
+```yaml
+sync_projects:
+  class: ProjectSyncJob
+  schedule: every day at 3am
+```
+
+No download stats — only version and description are synced.
+
+---
+
+### Phase 5 — Public Projects Page
+
+Add a read-only `ProjectsController#index` (`GET /projects`) visible to all visitors:
+
+- Loads `Project.where(is_featured: true).order(:position)` first, then the rest
+- Groups or tabs by `project_type` if useful
+- No `ProjectsController#show` needed initially — `url` links out directly
+
+---
+
+### Out of Scope (for now)
+
+- Download/install stats from RubyGems
+- GitHub star/fork counts
+- npm package support (model supports it, but no sync job)
+- Project images / logos

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,0 +1,16 @@
+class Project < ApplicationRecord
+  TYPES = %w[rubygem github npm other].freeze
+
+  validates :name, presence: true
+  validates :url, presence: true
+  validates :project_type, inclusion: { in: TYPES }
+  validates :rubygem_name, uniqueness: true, allow_nil: true
+
+  scope :featured, -> { where(is_featured: true) }
+  scope :by_position, -> { order(Arel.sql("position IS NULL, position ASC")) }
+  scope :featured_first, -> { order(is_featured: :desc).by_position }
+
+  def rubygem?
+    project_type == "rubygem"
+  end
+end

--- a/db/migrate/20260609130355_create_projects.rb
+++ b/db/migrate/20260609130355_create_projects.rb
@@ -1,0 +1,22 @@
+class CreateProjects < ActiveRecord::Migration[8.1]
+  def change
+    create_table :projects do |t|
+      t.string :name, null: false
+      t.text :description
+      t.string :url, null: false
+      t.string :source_url
+      t.string :project_type, null: false
+      t.string :rubygem_name
+      t.string :version
+      t.boolean :is_featured, null: false, default: false
+      t.integer :position
+      t.datetime :last_synced_at
+
+      t.timestamps
+    end
+
+    add_index :projects, :project_type
+    add_index :projects, :rubygem_name, unique: true, where: "rubygem_name IS NOT NULL"
+    add_index :projects, :position
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_27_135209) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_09_130355) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -81,6 +81,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_27_135209) do
     t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
     t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
     t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
+  end
+
+  create_table "projects", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.boolean "is_featured", default: false, null: false
+    t.datetime "last_synced_at"
+    t.string "name", null: false
+    t.integer "position"
+    t.string "project_type", null: false
+    t.string "rubygem_name"
+    t.string "source_url"
+    t.datetime "updated_at", null: false
+    t.string "url", null: false
+    t.string "version"
+    t.index ["position"], name: "index_projects_on_position"
+    t.index ["project_type"], name: "index_projects_on_project_type"
+    t.index ["rubygem_name"], name: "index_projects_on_rubygem_name", unique: true, where: "rubygem_name IS NOT NULL"
   end
 
   create_table "sessions", force: :cascade do |t|

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :project do
+    sequence(:name) { |n| "Test Project #{n}" }
+    url { "https://example.com/project" }
+    project_type { "github" }
+    is_featured { false }
+
+    trait :rubygem do
+      project_type { "rubygem" }
+      sequence(:rubygem_name) { |n| "my-gem-#{n}" }
+      version { "1.0.0" }
+    end
+
+    trait :featured do
+      is_featured { true }
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe Project, type: :model do
+  describe "validations" do
+    it "is valid with required attributes" do
+      expect(build(:project)).to be_valid
+    end
+
+    it "requires name" do
+      expect(build(:project, name: nil)).not_to be_valid
+    end
+
+    it "requires url" do
+      expect(build(:project, url: nil)).not_to be_valid
+    end
+
+    it "requires project_type to be in the allowlist" do
+      expect(build(:project, project_type: "invalid")).not_to be_valid
+    end
+
+    it "accepts all valid project types" do
+      Project::TYPES.each do |type|
+        expect(build(:project, project_type: type)).to be_valid
+      end
+    end
+
+    it "allows rubygem_name to be nil" do
+      expect(build(:project, rubygem_name: nil)).to be_valid
+    end
+
+    it "enforces uniqueness of rubygem_name when present" do
+      create(:project, :rubygem, rubygem_name: "my-gem")
+      expect(build(:project, :rubygem, rubygem_name: "my-gem")).not_to be_valid
+    end
+  end
+
+  describe "defaults" do
+    it "defaults is_featured to false" do
+      project = create(:project)
+      expect(project.is_featured).to be false
+    end
+  end
+
+  describe "scopes" do
+    let!(:unfeatured) { create(:project) }
+    let!(:featured)   { create(:project, :featured) }
+
+    describe ".featured" do
+      it "returns only featured projects" do
+        expect(Project.featured).to contain_exactly(featured)
+      end
+    end
+
+    describe ".featured_first" do
+      it "returns featured projects before unfeatured" do
+        results = Project.featured_first
+        expect(results.first).to eq(featured)
+      end
+    end
+
+    describe ".by_position" do
+      it "orders projects with nulls last" do
+        p1 = create(:project, position: 2)
+        p2 = create(:project, position: 1)
+        p3 = create(:project, position: nil)
+
+        results = Project.where(id: [p1.id, p2.id, p3.id]).by_position
+        expect(results.map(&:id)).to eq([p2.id, p1.id, p3.id])
+      end
+    end
+  end
+
+  describe "#rubygem?" do
+    it "returns true for rubygem type" do
+      expect(build(:project, :rubygem).rubygem?).to be true
+    end
+
+    it "returns false for other types" do
+      expect(build(:project, project_type: "github").rubygem?).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `projects` table with support for `rubygem`, `github`, `npm`, and `other` project types
- `Project` model with presence/inclusion validations, uniqueness constraint on `rubygem_name` (nullable), and scopes for featured/position ordering
- FactoryBot factory with `:rubygem` and `:featured` traits
- 13 model specs covering validations, defaults, scopes, and `#rubygem?` predicate

## Test plan

- [x] `bin/rspec spec/models/project_spec.rb` — 13 examples, 0 failures
- [x] `bin/cleanup` — 288 examples, 0 failures, 100% coverage, no brakeman warnings, no rubocop offenses

Part of the Projects Portfolio feature — see ROADMAP.md for full plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)