### PR TITLE
feat: admin CRUD for Projects (Phase 2)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,45 +4,6 @@
 
 Replace the ad-hoc `RubygemsService` display with a proper `Project` resource that supports any type of software project (RubyGems, GitHub repos, npm packages, etc.), admin-managed CRUD, and an optional daily sync for gem metadata.
 
-### Motivation
-
-The current `RubygemsService` only covers RubyGems and has no persistence — it fetches live on every page load (with caching). A persisted `Project` model gives full editorial control, supports non-gem projects, and decouples the public display from the upstream API.
-
----
-
-### Phase 1 — Project Model & Migration
-
-Create the `projects` table with fields that cover both manually-entered and API-synced projects:
-
-| Column | Type | Notes |
-|---|---|---|
-| `name` | string | display name |
-| `description` | text | short blurb |
-| `url` | string | live project / docs URL |
-| `source_url` | string | GitHub or repo link |
-| `project_type` | string | `rubygem`, `github`, `npm`, `other` |
-| `rubygem_name` | string | gem slug used for sync (nullable) |
-| `version` | string | current release (synced or manual) |
-| `is_featured` | boolean | pin to top of public list |
-| `position` | integer | manual sort order |
-| `last_synced_at` | datetime | set by sync job |
-| `timestamps` | | standard |
-
-Validations: `name` and `url` required; `project_type` in allowlist.
-
----
-
-### Phase 2 — Admin CRUD
-
-Add a `Admin::ProjectsController` (or route under the existing `dashboard/` namespace, matching current convention) with standard `index / new / create / edit / update / destroy` actions, gated behind `admin_only!`.
-
-- Index table shows name, type, version, last_synced_at, featured toggle
-- Form: all fields; `rubygem_name` shown only when type is `rubygem`
-- Stimulus controller to conditionally show/hide `rubygem_name` field based on `project_type` select
-- Flash notices on create/update/destroy
-
----
-
 ### Phase 3 — RubyGems Import Helper
 
 Add a one-click "Import from RubyGems" action (`POST /admin/projects/import_rubygems`) that:

--- a/app/controllers/dashboard/projects_controller.rb
+++ b/app/controllers/dashboard/projects_controller.rb
@@ -1,0 +1,56 @@
+module Dashboard
+  class ProjectsController < Dashboard::BaseController
+    before_action :set_project, only: %i[show edit update destroy]
+
+    def index
+      @pagy, @projects = pagy(Project.featured_first)
+    end
+
+    def show
+    end
+
+    def new
+      @project = Project.new
+    end
+
+    def edit
+    end
+
+    def create
+      @project = Project.new(project_params)
+
+      if @project.save
+        redirect_to dashboard_project_path(@project), notice: "Project was successfully created."
+      else
+        render :new, status: :unprocessable_content
+      end
+    end
+
+    def update
+      if @project.update(project_params)
+        redirect_to dashboard_project_path(@project), notice: "Project was successfully updated."
+      else
+        render :edit, status: :unprocessable_content
+      end
+    end
+
+    def destroy
+      @project.destroy!
+      redirect_to dashboard_projects_path, notice: "Project was successfully deleted.", status: :see_other
+    end
+
+    private
+
+    def set_project
+      @project = Project.find(params.require(:id))
+    end
+
+    def project_params
+      params.require(:project).permit(
+        :name, :description, :url, :source_url,
+        :project_type, :rubygem_name, :version,
+        :is_featured, :position
+      )
+    end
+  end
+end

--- a/app/javascript/controllers/project_type_controller.js
+++ b/app/javascript/controllers/project_type_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["rubygemGroup", "typeSelect"]
+
+  connect() {
+    this.toggle()
+  }
+
+  toggle() {
+    this.rubygemGroupTarget.hidden = this.typeSelectTarget.value !== "rubygem"
+  }
+}

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,8 +1,11 @@
 class Project < ApplicationRecord
   TYPES = %w[rubygem github npm other].freeze
 
+  SAFE_URL_PATTERN = /\Ahttps?:\/\/.+\z/i
+
   validates :name, presence: true
-  validates :url, presence: true
+  validates :url, presence: true, format: { with: SAFE_URL_PATTERN, message: "must start with http:// or https://" }
+  validates :source_url, format: { with: SAFE_URL_PATTERN, message: "must start with http:// or https://" }, allow_blank: true
   validates :project_type, inclusion: { in: TYPES }
   validates :rubygem_name, uniqueness: true, allow_nil: true
 

--- a/app/views/dashboard/_sidebar.html.erb
+++ b/app/views/dashboard/_sidebar.html.erb
@@ -20,6 +20,10 @@
       <%= link_to "Users", dashboard_users_path,
             class: "nav-link rounded #{controller_path == 'dashboard/users' ? 'active fw-semibold' : 'text-body'}" %>
     </li>
+    <li class="nav-item">
+      <%= link_to "Projects", dashboard_projects_path,
+            class: "nav-link rounded #{controller_path == 'dashboard/projects' ? 'active fw-semibold' : 'text-body'}" %>
+    </li>
 
   </ul>
 

--- a/app/views/dashboard/projects/_form.html.erb
+++ b/app/views/dashboard/projects/_form.html.erb
@@ -1,0 +1,88 @@
+<% form_url = project.persisted? ? dashboard_project_path(project) : dashboard_projects_path %>
+<%= form_with model: [:dashboard, project], url: form_url, class: "needs-validation" do |f| %>
+  <% if project.errors.any? %>
+    <div class="alert alert-danger">
+      <ul class="mb-0">
+        <% project.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div data-controller="project-type">
+    <div class="mb-3">
+      <%= f.label :name, class: "form-label" %>
+      <%= f.text_field :name, class: "form-control #{"is-invalid" if project.errors[:name].any?}" %>
+      <% if project.errors[:name].any? %>
+        <div class="invalid-feedback"><%= project.errors[:name].first %></div>
+      <% end %>
+    </div>
+
+    <div class="mb-3">
+      <%= f.label :description, class: "form-label" %>
+      <%= f.text_area :description, rows: 3, class: "form-control #{"is-invalid" if project.errors[:description].any?}" %>
+    </div>
+
+    <div class="mb-3">
+      <%= f.label :url, "Project URL", class: "form-label" %>
+      <%= f.url_field :url, class: "form-control #{"is-invalid" if project.errors[:url].any?}", placeholder: "https://" %>
+      <% if project.errors[:url].any? %>
+        <div class="invalid-feedback"><%= project.errors[:url].first %></div>
+      <% end %>
+    </div>
+
+    <div class="mb-3">
+      <%= f.label :source_url, "Source URL", class: "form-label" %>
+      <%= f.url_field :source_url, class: "form-control", placeholder: "https://github.com/..." %>
+    </div>
+
+    <div class="mb-3">
+      <%= f.label :project_type, class: "form-label" %>
+      <%= f.select :project_type,
+            Project::TYPES.map { |t| [t.humanize, t] },
+            { include_blank: "Select type" },
+            class: "form-select #{"is-invalid" if project.errors[:project_type].any?}",
+            data: { project_type_target: "typeSelect", action: "change->project-type#toggle" } %>
+      <% if project.errors[:project_type].any? %>
+        <div class="invalid-feedback"><%= project.errors[:project_type].first %></div>
+      <% end %>
+    </div>
+
+    <div class="mb-3" data-project-type-target="rubygemGroup">
+      <%= f.label :rubygem_name, "RubyGems name", class: "form-label" %>
+      <%= f.text_field :rubygem_name, class: "form-control #{"is-invalid" if project.errors[:rubygem_name].any?}",
+            placeholder: "my-gem-name" %>
+      <% if project.errors[:rubygem_name].any? %>
+        <div class="invalid-feedback"><%= project.errors[:rubygem_name].first %></div>
+      <% end %>
+      <div class="form-text">Gem slug as it appears on rubygems.org — used for the daily sync job.</div>
+    </div>
+
+    <div class="mb-3">
+      <%= f.label :version, class: "form-label" %>
+      <%= f.text_field :version, class: "form-control", placeholder: "1.0.0" %>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-sm-6">
+        <%= f.label :position, class: "form-label" %>
+        <%= f.number_field :position, class: "form-control", min: 1, placeholder: "Leave blank for no order" %>
+        <div class="form-text">Lower numbers appear first. Blank = unordered.</div>
+      </div>
+    </div>
+
+    <div class="mb-4">
+      <div class="form-check">
+        <%= f.check_box :is_featured, class: "form-check-input" %>
+        <%= f.label :is_featured, "Featured project", class: "form-check-label" %>
+      </div>
+    </div>
+
+    <div class="d-flex gap-2">
+      <%= f.submit project.persisted? ? "Save changes" : "Create project", class: "btn btn-primary" %>
+      <% back = project.persisted? ? dashboard_project_path(project) : dashboard_projects_path %>
+      <%= link_to "Cancel", back, class: "btn btn-outline-secondary" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/dashboard/projects/edit.html.erb
+++ b/app/views/dashboard/projects/edit.html.erb
@@ -1,0 +1,11 @@
+<%= content_for :title, "Edit #{@project.name}" %>
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0">Edit Project</h1>
+</div>
+
+<div class="card shadow-sm">
+  <div class="card-body">
+    <%= render "form", project: @project %>
+  </div>
+</div>

--- a/app/views/dashboard/projects/index.html.erb
+++ b/app/views/dashboard/projects/index.html.erb
@@ -1,0 +1,54 @@
+<%= content_for :title, "Projects" %>
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0">Projects</h1>
+  <%= link_to "New Project", new_dashboard_project_path, class: "btn btn-primary" %>
+</div>
+
+<div class="card shadow-sm">
+  <div class="table-responsive">
+    <table class="table table-hover mb-0">
+      <thead class="table-dark">
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Version</th>
+          <th>Featured</th>
+          <th>Last Synced</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @projects.each do |project| %>
+          <tr>
+            <td><%= link_to project.name, dashboard_project_path(project) %></td>
+            <td><span class="badge text-bg-secondary"><%= project.project_type %></span></td>
+            <td class="text-muted small"><%= project.version.presence || "—" %></td>
+            <td>
+              <% if project.is_featured? %>
+                <span class="badge text-bg-warning">Featured</span>
+              <% end %>
+            </td>
+            <td class="text-muted small">
+              <%= project.last_synced_at ? time_ago_in_words(project.last_synced_at) + " ago" : "—" %>
+            </td>
+            <td>
+              <div class="d-flex gap-1 justify-content-end">
+                <%= link_to "Edit", edit_dashboard_project_path(project), class: "btn btn-sm btn-outline-secondary" %>
+                <%= button_to "Delete", dashboard_project_path(project), method: :delete,
+                      class: "btn btn-sm btn-outline-danger",
+                      form: { data: { turbo_confirm: "Delete project #{project.name}?" } } %>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<% if @pagy.pages > 1 %>
+  <div class="mt-3">
+    <%== @pagy.series_nav(:bootstrap) %>
+  </div>
+<% end %>

--- a/app/views/dashboard/projects/new.html.erb
+++ b/app/views/dashboard/projects/new.html.erb
@@ -1,0 +1,11 @@
+<%= content_for :title, "New Project" %>
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0">New Project</h1>
+</div>
+
+<div class="card shadow-sm">
+  <div class="card-body">
+    <%= render "form", project: @project %>
+  </div>
+</div>

--- a/app/views/dashboard/projects/show.html.erb
+++ b/app/views/dashboard/projects/show.html.erb
@@ -1,0 +1,54 @@
+<%= content_for :title, @project.name %>
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0"><%= @project.name %></h1>
+  <%= link_to "Edit", edit_dashboard_project_path(@project), class: "btn btn-outline-secondary" %>
+</div>
+
+<div class="card shadow-sm mb-4">
+  <div class="card-body">
+    <dl class="row mb-0">
+      <dt class="col-sm-3">Type</dt>
+      <dd class="col-sm-9"><span class="badge text-bg-secondary"><%= @project.project_type %></span></dd>
+
+      <dt class="col-sm-3">URL</dt>
+      <dd class="col-sm-9"><%= link_to @project.url, @project.url, target: "_blank", rel: "noopener" %></dd>
+
+      <% if @project.source_url.present? %>
+        <dt class="col-sm-3">Source</dt>
+        <dd class="col-sm-9"><%= link_to @project.source_url, @project.source_url, target: "_blank", rel: "noopener" %></dd>
+      <% end %>
+
+      <% if @project.description.present? %>
+        <dt class="col-sm-3">Description</dt>
+        <dd class="col-sm-9"><%= @project.description %></dd>
+      <% end %>
+
+      <% if @project.rubygem? %>
+        <dt class="col-sm-3">RubyGems name</dt>
+        <dd class="col-sm-9"><code><%= @project.rubygem_name %></code></dd>
+      <% end %>
+
+      <dt class="col-sm-3">Version</dt>
+      <dd class="col-sm-9"><%= @project.version.presence || "—" %></dd>
+
+      <dt class="col-sm-3">Position</dt>
+      <dd class="col-sm-9"><%= @project.position.presence || "—" %></dd>
+
+      <dt class="col-sm-3">Featured</dt>
+      <dd class="col-sm-9"><%= @project.is_featured? ? "Yes" : "No" %></dd>
+
+      <dt class="col-sm-3">Last Synced</dt>
+      <dd class="col-sm-9 mb-0">
+        <%= @project.last_synced_at ? "#{time_ago_in_words(@project.last_synced_at)} ago" : "Never" %>
+      </dd>
+    </dl>
+  </div>
+</div>
+
+<div class="d-flex gap-2">
+  <%= link_to "Back to projects", dashboard_projects_path, class: "btn btn-link ps-0" %>
+  <%= button_to "Delete", dashboard_project_path(@project), method: :delete,
+        class: "btn btn-outline-danger btn-sm",
+        form: { data: { turbo_confirm: "Delete project #{@project.name}?" } } %>
+</div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -10,6 +10,28 @@
       "line": 30,
       "confidence": "High",
       "note": "Admin-only dashboard; permitting :admin is intentional — only admins can reach this controller"
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "e4f0e835815d694ad573bcc6ea20dbed52b94cda7c685bf1f7a3d96ca3ce217a",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/dashboard/projects/show.html.erb",
+      "line": 15,
+      "confidence": "Weak",
+      "note": "False positive — Project#url is validated to match /\\Ahttps?:\\/\\/.+\\z/i, preventing javascript: and other unsafe protocols"
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "00a275aa763572581a3cf332caf79fb965838bac0a578ee5143e476d014f93e1",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/dashboard/projects/show.html.erb",
+      "line": 19,
+      "confidence": "Weak",
+      "note": "False positive — Project#source_url is validated to match /\\Ahttps?:\\/\\/.+\\z/i, preventing javascript: and other unsafe protocols"
     }
   ]
 }

--- a/config/routes/dashboard.rb
+++ b/config/routes/dashboard.rb
@@ -7,6 +7,7 @@ namespace :dashboard, path: "admin", constraints: DASHBOARD_ADMIN_CONSTRAINT do
   resources :articles
   resources :tags
   resources :users
+  resources :projects
   resources :sessions, only: [:destroy]
   root to: "dashboard#index"
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe Project, type: :model do
       expect(build(:project, rubygem_name: nil)).to be_valid
     end
 
+    it "rejects url without http/https scheme" do
+      expect(build(:project, url: "javascript:alert(1)")).not_to be_valid
+    end
+
+    it "rejects source_url without http/https scheme" do
+      expect(build(:project, source_url: "ftp://example.com")).not_to be_valid
+    end
+
+    it "allows blank source_url" do
+      expect(build(:project, source_url: nil)).to be_valid
+    end
+
     it "enforces uniqueness of rubygem_name when present" do
       create(:project, :rubygem, rubygem_name: "my-gem")
       expect(build(:project, :rubygem, rubygem_name: "my-gem")).not_to be_valid

--- a/spec/requests/dashboard/projects_spec.rb
+++ b/spec/requests/dashboard/projects_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe "Dashboard::Projects", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:project) { create(:project) }
+
+  context "when unauthenticated" do
+    it "returns 404 for all actions (route constraint)" do
+      get dashboard_projects_path
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context "when authenticated as admin" do
+    before { sign_in_as(admin) }
+
+    describe "GET /admin/projects" do
+      it "returns 200" do
+        project
+        get dashboard_projects_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "GET /admin/projects/:id" do
+      it "returns 200" do
+        get dashboard_project_path(project)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "GET /admin/projects/new" do
+      it "returns 200" do
+        get new_dashboard_project_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "GET /admin/projects/:id/edit" do
+      it "returns 200" do
+        get edit_dashboard_project_path(project)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "POST /admin/projects" do
+      let(:valid_params) { { project: { name: "My Gem", url: "https://example.com", project_type: "rubygem" } } }
+
+      it "creates a project and redirects to show" do
+        expect {
+          post dashboard_projects_path, params: valid_params
+        }.to change(Project, :count).by(1)
+        expect(response).to redirect_to(dashboard_project_path(Project.last))
+      end
+
+      it "renders new with 422 on missing name" do
+        post dashboard_projects_path, params: { project: { name: "", url: "https://example.com", project_type: "github" } }
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it "renders new with 422 on invalid project_type" do
+        post dashboard_projects_path, params: { project: { name: "X", url: "https://example.com", project_type: "invalid" } }
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    describe "PATCH /admin/projects/:id" do
+      it "updates the project and redirects to show" do
+        patch dashboard_project_path(project), params: { project: { name: "Updated Name" } }
+        expect(project.reload.name).to eq("Updated Name")
+        expect(response).to redirect_to(dashboard_project_path(project))
+      end
+
+      it "renders edit with 422 on invalid params" do
+        patch dashboard_project_path(project), params: { project: { name: "" } }
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    describe "DELETE /admin/projects/:id" do
+      it "destroys the project and redirects to index" do
+        project
+        expect {
+          delete dashboard_project_path(project)
+        }.to change(Project, :count).by(-1)
+        expect(response).to redirect_to(dashboard_projects_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Dashboard::ProjectsController` with full CRUD (index/show/new/edit/create/update/destroy), gated behind `admin_only!` via `BaseController`
- Five views: index table showing name, type, version, featured badge, and last synced; show detail card; new/edit wrappers; shared `_form` partial
- Stimulus `project-type` controller hides the RubyGems name field unless `project_type` is set to `rubygem`
- Projects link added to the dashboard sidebar with active state highlighting
- `url` and `source_url` validated to `http/https` only (`\Ahttps?:\/\/.+\z`) to prevent XSS; brakeman false positives documented in `brakeman.ignore`
- Removes completed phases 1 & 2 from ROADMAP

## Test plan

- [x] `bin/rspec spec/requests/dashboard/projects_spec.rb` — 11 examples, 0 failures
- [x] `bin/cleanup` — 302 examples, 0 failures, 100% coverage, no brakeman warnings, no rubocop offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)