### PR TITLE
feat: Phase 4 — Daily gem metadata sync with Solid Queue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,8 @@ GEM
       rubocop (>= 1)
       smart_properties
     erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
     factory_bot (6.6.0)
       activesupport (>= 6.1.0)
     factory_bot_rails (6.5.1)
@@ -156,6 +158,9 @@ GEM
     ffi (1.17.4-x86_64-linux-musl)
     friendly_id (5.7.0)
       activerecord (>= 4.0.0)
+    fugit (1.12.1)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     fuubar (2.5.1)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
@@ -312,6 +317,7 @@ GEM
     public_suffix (7.0.5)
     puma (8.0.2)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
     rack-session (2.1.2)
@@ -445,6 +451,13 @@ GEM
       simplecov
     simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
+    solid_queue (1.4.0)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      concurrent-ruby (>= 1.3.1)
+      fugit (~> 1.11)
+      railties (>= 7.1)
+      thor (>= 1.3.1)
     sqlite3 (2.9.4-aarch64-linux-gnu)
     sqlite3 (2.9.4-aarch64-linux-musl)
     sqlite3 (2.9.4-arm-linux-gnu)
@@ -549,6 +562,7 @@ DEPENDENCIES
   selenium-webdriver
   simplecov (~> 0.22.0)
   simplecov-json
+  solid_queue
   sqlite3 (>= 2.1)
   stimulus-rails
   test-prof

--- a/app/jobs/project_sync_job.rb
+++ b/app/jobs/project_sync_job.rb
@@ -1,0 +1,35 @@
+require "net/http"
+require "json"
+
+class ProjectSyncJob < ApplicationJob
+  queue_as :default
+
+  RUBYGEMS_GEM_URL = "https://rubygems.org/api/v1/gems/%s.json"
+
+  def perform
+    Project.where.not(rubygem_name: nil).find_each do |project|
+      sync_gem(project)
+    end
+  end
+
+  private
+
+  def sync_gem(project)
+    url      = URI(format(RUBYGEMS_GEM_URL, project.rubygem_name))
+    response = Net::HTTP.get_response(url)
+
+    unless response.is_a?(Net::HTTPSuccess)
+      Rails.logger.warn("[ProjectSyncJob] #{project.rubygem_name}: HTTP #{response.code}")
+      return
+    end
+
+    data = JSON.parse(response.body)
+    project.update!(
+      version:        data["version"],
+      description:    data["info"],
+      last_synced_at: Time.current
+    )
+  rescue StandardError => e
+    Rails.logger.error("[ProjectSyncJob] #{project.rubygem_name}: #{e.class} — #{e.message}")
+  end
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -25,3 +25,8 @@ test:
 production:
   <<: *default
   database: storage/production.sqlite3
+
+queue:
+  <<: *default
+  database: storage/queue.sqlite3
+  migrations_paths: db/queue_migrate

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,8 @@ Rails.application.configure do
 
   # Use a durable adapter for Active Job in production by default.
   # Override via ACTIVE_JOB_QUEUE_ADAPTER environment variable (e.g. "sidekiq", "solid_queue").
-  config.active_job.queue_adapter = ENV.fetch("ACTIVE_JOB_QUEUE_ADAPTER", "async").to_sym
+  config.active_job.queue_adapter = :solid_queue
+  config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/gems/app.rb
+++ b/config/gems/app.rb
@@ -1,3 +1,4 @@
+gem "solid_queue"
 gem "inline_svg"
 gem "ruby-vips", "~> 2.0"
 # gem "name_of_person"

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,7 +36,7 @@ plugin :tmp_restart
 
 # Run the Solid Queue supervisor inside of Puma for single-server deployments.
 # Uncomment the following line if you install the solid_queue gem:
-# plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
+plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
 
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -1,0 +1,18 @@
+default: &default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: "*"
+      threads: 3
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+      polling_interval: 0.1
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,0 +1,18 @@
+# examples:
+#   periodic_cleanup:
+#     class: CleanSoftDeletedRecordsJob
+#     queue: background
+#     args: [ 1000, { batch_size: 500 } ]
+#     schedule: every hour
+#   periodic_cleanup_with_command:
+#     command: "SoftDeletedRecord.due.delete_all"
+#     priority: 2
+#     schedule: at 5am every day
+
+production:
+  clear_solid_queue_finished_jobs:
+    command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+    schedule: every hour at minute 12
+  sync_projects:
+    class: ProjectSyncJob
+    schedule: every day at 3am

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -1,0 +1,129 @@
+ActiveRecord::Schema[7.1].define(version: 1) do
+  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "concurrency_key", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.index [ "concurrency_key", "priority", "job_id" ], name: "index_solid_queue_blocked_executions_for_release"
+    t.index [ "expires_at", "concurrency_key" ], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index [ "job_id" ], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.datetime "created_at", null: false
+    t.index [ "job_id" ], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index [ "process_id", "job_id" ], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.index [ "job_id" ], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.string "class_name", null: false
+    t.text "arguments"
+    t.integer "priority", default: 0, null: false
+    t.string "active_job_id"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index [ "active_job_id" ], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index [ "class_name" ], name: "index_solid_queue_jobs_on_class_name"
+    t.index [ "finished_at" ], name: "index_solid_queue_jobs_on_finished_at"
+    t.index [ "queue_name", "finished_at" ], name: "index_solid_queue_jobs_for_filtering"
+    t.index [ "scheduled_at", "finished_at" ], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.datetime "created_at", null: false
+    t.index [ "queue_name" ], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", force: :cascade do |t|
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.bigint "supervisor_id"
+    t.integer "pid", null: false
+    t.string "hostname"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.index [ "last_heartbeat_at" ], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index [ "name", "supervisor_id" ], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index [ "supervisor_id" ], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.index [ "job_id" ], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index [ "priority", "job_id" ], name: "index_solid_queue_poll_all"
+    t.index [ "queue_name", "priority", "job_id" ], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "task_key", null: false
+    t.datetime "run_at", null: false
+    t.datetime "created_at", null: false
+    t.index [ "job_id" ], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index [ "task_key", "run_at" ], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "schedule", null: false
+    t.string "command", limit: 2048
+    t.string "class_name"
+    t.text "arguments"
+    t.string "queue_name"
+    t.integer "priority", default: 0
+    t.boolean "static", default: true, null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index [ "key" ], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index [ "static" ], name: "index_solid_queue_recurring_tasks_on_static"
+  end
+
+  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "scheduled_at", null: false
+    t.datetime "created_at", null: false
+    t.index [ "job_id" ], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index [ "scheduled_at", "priority", "job_id" ], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "value", default: 1, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index [ "expires_at" ], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index [ "key", "value" ], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index [ "key" ], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+end

--- a/spec/jobs/project_sync_job_spec.rb
+++ b/spec/jobs/project_sync_job_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe ProjectSyncJob, type: :job do
+  let!(:gem_project) do
+    create(:project, :rubygem,
+      rubygem_name: "safe_memoize",
+      version: "1.0.0",
+      description: "Old description")
+  end
+
+  let!(:non_gem_project) { create(:project) }
+
+  let(:gem_api_response) do
+    { "version" => "1.8.0", "info" => "Updated description." }.to_json
+  end
+
+  def stub_rubygems_api(name, body: gem_api_response, status: "200")
+    stub_request(:get, "https://rubygems.org/api/v1/gems/#{name}.json")
+      .to_return(status: status.to_i, body: body, headers: { "Content-Type" => "application/json" })
+  end
+
+  describe "#perform" do
+    it "updates version and description for projects with a rubygem_name" do
+      stub_rubygems_api("safe_memoize")
+
+      described_class.perform_now
+
+      gem_project.reload
+      expect(gem_project.version).to eq("1.8.0")
+      expect(gem_project.description).to eq("Updated description.")
+      expect(gem_project.last_synced_at).to be_within(5.seconds).of(Time.current)
+    end
+
+    it "does not touch projects without a rubygem_name" do
+      stub_rubygems_api("safe_memoize")
+
+      expect { described_class.perform_now }
+        .not_to change { non_gem_project.reload.updated_at }
+    end
+
+    it "continues processing remaining gems when one raises an error" do
+      second_gem = create(:project, :rubygem, rubygem_name: "other_gem", version: "0.1.0")
+
+      stub_request(:get, "https://rubygems.org/api/v1/gems/safe_memoize.json")
+        .to_raise(SocketError.new("connection failed"))
+      stub_rubygems_api("other_gem", body: { "version" => "0.2.0", "info" => "desc" }.to_json)
+
+      expect { described_class.perform_now }.not_to raise_error
+
+      expect(second_gem.reload.version).to eq("0.2.0")
+    end
+
+    it "logs a warning and skips update when the API returns a non-success status" do
+      stub_rubygems_api("safe_memoize", status: "404", body: "Not found")
+
+      expect(Rails.logger).to receive(:warn).with(/safe_memoize.*404/)
+
+      described_class.perform_now
+
+      expect(gem_project.reload.version).to eq("1.0.0")
+    end
+
+    it "does not overwrite name, url, is_featured, or position" do
+      stub_rubygems_api("safe_memoize")
+
+      original = gem_project.slice(:name, :url, :is_featured, :position)
+      described_class.perform_now
+      gem_project.reload
+
+      expect(gem_project.name).to eq(original["name"])
+      expect(gem_project.url).to eq(original["url"])
+      expect(gem_project.is_featured).to eq(original["is_featured"])
+      expect(gem_project.position).to eq(original["position"])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Installs `solid_queue` and wires it up as the production Active Job adapter, with the Puma plugin enabled via `SOLID_QUEUE_IN_PUMA`
- Adds `ProjectSyncJob` which fetches `version` and `description` from the RubyGems API for every `Project` with a `rubygem_name`, updating only those fields plus `last_synced_at` — editorial fields (`name`, `url`, `is_featured`, `position`) are never touched
- Errors are silenced per-gem (logged and skipped) so one bad gem never aborts the batch
- Schedules the job daily at 3am via `config/recurring.yml` (Solid Queue recurring jobs)

## Test plan

- [ ] 5 new job specs pass (`bin/rspec spec/jobs/project_sync_job_spec.rb`)
- [ ] Happy path: version + description + `last_synced_at` updated
- [ ] Non-gem projects untouched
- [ ] One failing gem does not abort the batch
- [ ] Non-2xx API response logs warning and leaves record unchanged
- [ ] Editorial fields (`name`, `url`, `is_featured`, `position`) are preserved
- [ ] Full suite green (`bin/cleanup`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)