### PR TITLE
feat: Phase 5 — Public projects index page

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,0 +1,7 @@
+class ProjectsController < ApplicationController
+  allow_unauthenticated_access
+
+  def index
+    @projects = Project.featured_first
+  end
+end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,0 +1,55 @@
+<%= content_for :title, "Projects" %>
+
+<div class="row mb-4">
+  <div class="col-sm-8 mx-auto text-center">
+    <h1 class="article-feed-header">Projects</h1>
+    <p class="text-muted">Open-source gems and tools I maintain.</p>
+  </div>
+</div>
+
+<div class="row g-4 col-md-10 mx-auto">
+  <% @projects.each do |project| %>
+    <div class="col-md-6">
+      <div class="card h-100 shadow-sm <%= 'border-warning' if project.is_featured? %>">
+        <div class="card-body d-flex flex-column">
+          <div class="d-flex justify-content-between align-items-start mb-2">
+            <h5 class="card-title mb-0">
+              <%= link_to project.name, project.url,
+                    target: "_blank", rel: "noopener noreferrer",
+                    class: "text-decoration-none stretched-link" %>
+            </h5>
+            <div class="d-flex gap-1 flex-shrink-0 ms-2">
+              <% if project.is_featured? %>
+                <span class="badge text-bg-warning">Featured</span>
+              <% end %>
+              <span class="badge text-bg-secondary"><%= project.project_type %></span>
+            </div>
+          </div>
+
+          <% if project.description.present? %>
+            <p class="card-text text-muted small flex-grow-1"><%= project.description %></p>
+          <% end %>
+
+          <div class="mt-auto pt-2 d-flex justify-content-between align-items-center">
+            <% if project.version.present? %>
+              <span class="text-muted small">v<%= project.version %></span>
+            <% else %>
+              <span></span>
+            <% end %>
+            <% if project.source_url.present? %>
+              <%= link_to "Source", project.source_url,
+                    target: "_blank", rel: "noopener noreferrer",
+                    class: "btn btn-sm btn-outline-secondary position-relative" %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <% if @projects.empty? %>
+    <div class="col-12 text-center text-muted py-5">
+      <p>No projects yet.</p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -7,6 +7,7 @@
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav ms-auto align-items-center">
         <li class="nav-item"><%= link_to "Articles", articles_path, class: "nav-link" %></li>
+        <li class="nav-item"><%= link_to "Projects", projects_path, class: "nav-link" %></li>
         <% if admin? %>
           <li class="nav-item"><%= link_to "Admin", dashboard_root_path, class: "nav-link" %></li>
           <li class="nav-item d-flex align-items-center">

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,6 @@
 # Ignore paths that SimpleCov also filters so both tools agree on the denominator
 ignore:
   - "app/mailers/**"
-  - "app/jobs/**"
   - "app/channels/**"
   - "lib/**"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   draw :dashboard
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 
+  resources :projects, only: [:index]
   resources :articles, only: %i[index show] do
     collection do
       get :image_library, to: 'articles/image_library#index'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,7 +10,6 @@ if ENV["RAILS_ENV"] ||= "test"
   SimpleCov.start "rails" do
     add_filter "/lib/"
     add_filter "/app/channels/"
-    add_filter "/app/jobs/"
     add_filter "/app/mailers/"
   end
 end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "Projects", type: :request do
     end
 
     it "renders featured projects before non-featured" do
-      non_featured = create(:project, name: "Plain Gem", is_featured: false)
-      featured     = create(:project, name: "Star Gem",  is_featured: true)
+      create(:project, name: "Plain Gem", is_featured: false)
+      create(:project, name: "Star Gem",  is_featured: true)
 
       get projects_path
 

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe "Projects", type: :request do
+  describe "GET /projects" do
+    it "returns 200 for unauthenticated visitors" do
+      get projects_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders featured projects before non-featured" do
+      non_featured = create(:project, name: "Plain Gem", is_featured: false)
+      featured     = create(:project, name: "Star Gem",  is_featured: true)
+
+      get projects_path
+
+      expect(response.body.index("Star Gem")).to be < response.body.index("Plain Gem")
+    end
+
+    it "renders an external link to the project url" do
+      create(:project, name: "My Tool", url: "https://example.com/my-tool")
+
+      get projects_path
+
+      expect(response.body).to include('href="https://example.com/my-tool"')
+    end
+
+    it "shows the version when present" do
+      create(:project, :rubygem, version: "3.2.1")
+
+      get projects_path
+
+      expect(response.body).to include("v3.2.1")
+    end
+
+    it "shows a source link when source_url is present" do
+      create(:project, source_url: "https://github.com/example/repo")
+
+      get projects_path
+
+      expect(response.body).to include('href="https://github.com/example/repo"')
+    end
+
+    it "renders an empty state when there are no projects" do
+      get projects_path
+      expect(response.body).to include("No projects yet")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `GET /projects` visible to all visitors (no auth required)
- Featured projects sort first via the existing `featured_first` scope; each card links out to the project `url` directly — no `#show` route needed
- Adds a Projects link to the navbar
- Removes `app/jobs` from SimpleCov filters so job coverage is now tracked

## Test plan

- [ ] 6 request specs pass (`bin/rspec spec/requests/projects_spec.rb`)
- [ ] Unauthenticated visitors can access `/projects`
- [ ] Featured projects appear before non-featured
- [ ] Project cards link to external `url`
- [ ] Version and source link render when present
- [ ] Empty state shown when no projects exist
- [ ] Full suite green (`bin/cleanup`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)