### PR TITLE
Fix cover image and og_images rake task on production

### DIFF
--- a/app/views/dashboard/articles/_cover_image.html.erb
+++ b/app/views/dashboard/articles/_cover_image.html.erb
@@ -1,0 +1,11 @@
+<div id="cover-image-<%= article.id %>" class="card shadow-sm mb-3">
+  <div class="card-body text-center">
+    <h6 class="card-title text-muted small text-uppercase mb-3">Cover Image</h6>
+    <% if article.image.attached? %>
+      <%= image_tag rails_blob_url(article.image),
+            class: "img-fluid rounded", alt: article.title %>
+    <% else %>
+      <p class="text-muted small mb-0">No cover image attached.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/dashboard/articles/show.html.erb
+++ b/app/views/dashboard/articles/show.html.erb
@@ -49,16 +49,7 @@
       </div>
     </div>
 
-    <% if @article.image.attached? %>
-      <div class="card shadow-sm">
-        <div class="card-body text-center">
-          <h6 class="card-title text-muted small text-uppercase mb-3">Cover Image</h6>
-          <%= image_tag @article.image.variant(resize_to_limit: [400, 300]),
-                class: "img-fluid rounded", alt: @article.title %>
-        </div>
-      </div>
-    <% end %>
-
+    <%= render "cover_image", article: @article %>
     <%= render "og_card", article: @article %>
   </div>
 </div>

--- a/lib/tasks/og_images.rake
+++ b/lib/tasks/og_images.rake
@@ -21,12 +21,19 @@ namespace :og_images do
     failed  = []
 
     scope.find_each do |article|
-      OgImageGenerationJob.perform_now(article.id)
-      puts "  [OK] ##{article.id} → #{article.slug}"
-      success += 1
-    rescue => e
-      puts "  [FAIL] ##{article.id} #{article.slug}: #{e.class}: #{e.message}"
-      failed << article.id
+      begin
+        OgImageGenerationJob.perform_now(article.id)
+      rescue => e
+        Rails.logger.warn("[og_images:generate] article=#{article.id}: #{e.class}: #{e.message}")
+      end
+
+      if article.reload.og_image.attached?
+        puts "  [OK] ##{article.id} → #{article.slug}"
+        success += 1
+      else
+        puts "  [FAIL] ##{article.id} #{article.slug}: OG image was not attached"
+        failed << article.id
+      end
     end
 
     puts "\nDone. #{success} OG image(s) generated."


### PR DESCRIPTION
## Summary

- **Fix broken cover image on show page**: `image.variant()` triggers lazy variant processing on first request against cloud storage — the processed file isn't ready immediately after upload, causing a broken image until hard refresh. Switched to `rails_blob_url(article.image)` which serves the raw blob directly (no processing needed, always available). Also extracted the cover image section into a `_cover_image` partial with a stable DOM ID (`cover-image-<id>`), matching the `_og_card` pattern for consistency.
- **Fix `og_images:generate` false failures**: The rake task previously determined pass/fail by whether `perform_now` raised an exception. If the job enqueued asynchronously or raised after successfully attaching the image, articles were incorrectly reported as failed. Now reloads the article after the job runs and checks `og_image.attached?` — the only outcome that matters. Exceptions are logged as warnings rather than counted as task failures.

## Test plan

- [ ] Edit an article on production, upload a new cover image, save — confirm cover image appears immediately on the show page without a hard refresh
- [ ] Run `bin/rails og_images:generate` — confirm all successfully generated articles show `[OK]`, not `[FAIL]`
- [ ] `bin/rspec` — 359 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)