### PR TITLE
Fix TomSelect controller initialize() name conflict

### DIFF
--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -15,14 +15,14 @@ export default class extends Controller {
 
   waitForTomSelect() {
     if (typeof TomSelect !== 'undefined') {
-      this.initialize()
+      this.setupTomSelect()
     } else {
       // TomSelect not loaded yet, wait and try again
       setTimeout(() => this.waitForTomSelect(), 50)
     }
   }
 
-  initialize() {
+  setupTomSelect() {
     // Get CSRF token for AJAX requests
     const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
 


### PR DESCRIPTION
## Summary

- Renamed the custom `initialize()` method in `tom_select_controller.js` to `setupTomSelect()`
- `initialize()` is a reserved Stimulus lifecycle callback — Stimulus was calling it automatically on controller instantiation, before `connect()` and before the TomSelect CDN script had a chance to load, resulting in `ReferenceError: TomSelect is not defined`
- Updated the one call site in `waitForTomSelect()` to call `this.setupTomSelect()` instead

## Test plan

- [ ] Navigate to Dashboard → Articles → New Article
- [ ] Confirm no console errors on page load
- [ ] Confirm the tag select field renders correctly with TomSelect
- [ ] Confirm tag creation and selection works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)