### PR TITLE
Redirect www to bare domain to fix Active Storage CORS error

### DIFF
--- a/config/initializers/www_redirect.rb
+++ b/config/initializers/www_redirect.rb
@@ -1,0 +1,17 @@
+class WwwRedirect
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if env["HTTP_HOST"]&.start_with?("www.")
+      host = env["HTTP_HOST"].delete_prefix("www.")
+      location = "https://#{host}#{env['REQUEST_URI']}"
+      [301, { "Location" => location, "Content-Type" => "text/html", "Content-Length" => "0" }, []]
+    else
+      @app.call(env)
+    end
+  end
+end
+
+Rails.application.config.middleware.insert_before(ActionDispatch::SSL, WwwRedirect) if Rails.env.production?


### PR DESCRIPTION
## Summary

- Adds a small Rack middleware (`WwwRedirect`) that 301-redirects any `www.eclecticcoding.com` request to `eclecticcoding.com` before Rails processes it
- Middleware is inserted before `ActionDispatch::SSL` and only active in production
- Eliminates the CORS error on Active Storage direct uploads: when a visitor lands on `www.`, their browser was sending XHR to `eclecticcoding.com/rails/active_storage/direct_uploads` (the `APP_HOST` value), which the browser treated as cross-origin and blocked

## Test plan

- [ ] Deploy to production
- [ ] Visit `https://www.eclecticcoding.com` — confirm 301 redirect to `https://eclecticcoding.com`
- [ ] Navigate to Dashboard → Articles → New Article
- [ ] Upload a cover image — confirm no CORS error in the console and upload succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)