### PR TITLE
Add Solid Queue migration for queue database tables

### DIFF
--- a/db/queue_migrate/20260610000001_create_solid_queue_tables.rb
+++ b/db/queue_migrate/20260610000001_create_solid_queue_tables.rb
@@ -1,0 +1,139 @@
+class CreateSolidQueueTables < ActiveRecord::Migration[7.1]
+  def change
+    create_table :solid_queue_jobs do |t|
+      t.string   :queue_name,      null: false
+      t.string   :class_name,      null: false
+      t.text     :arguments
+      t.integer  :priority,        default: 0, null: false
+      t.string   :active_job_id
+      t.datetime :scheduled_at
+      t.datetime :finished_at
+      t.string   :concurrency_key
+      t.timestamps null: false
+
+      t.index :active_job_id
+      t.index :class_name
+      t.index :finished_at
+      t.index [ :queue_name, :finished_at ], name: "index_solid_queue_jobs_for_filtering"
+      t.index [ :scheduled_at, :finished_at ], name: "index_solid_queue_jobs_for_alerting"
+    end
+
+    create_table :solid_queue_blocked_executions do |t|
+      t.bigint   :job_id,          null: false
+      t.string   :queue_name,      null: false
+      t.integer  :priority,        default: 0, null: false
+      t.string   :concurrency_key, null: false
+      t.datetime :expires_at,      null: false
+      t.datetime :created_at,      null: false
+
+      t.index [ :concurrency_key, :priority, :job_id ], name: "index_solid_queue_blocked_executions_for_release"
+      t.index [ :expires_at, :concurrency_key ], name: "index_solid_queue_blocked_executions_for_maintenance"
+      t.index :job_id, name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+    end
+
+    create_table :solid_queue_claimed_executions do |t|
+      t.bigint   :job_id,     null: false
+      t.bigint   :process_id
+      t.datetime :created_at, null: false
+
+      t.index :job_id, name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+      t.index [ :process_id, :job_id ], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+    end
+
+    create_table :solid_queue_failed_executions do |t|
+      t.bigint   :job_id,     null: false
+      t.text     :error
+      t.datetime :created_at, null: false
+
+      t.index :job_id, name: "index_solid_queue_failed_executions_on_job_id", unique: true
+    end
+
+    create_table :solid_queue_pauses do |t|
+      t.string   :queue_name, null: false
+      t.datetime :created_at, null: false
+
+      t.index :queue_name, name: "index_solid_queue_pauses_on_queue_name", unique: true
+    end
+
+    create_table :solid_queue_processes do |t|
+      t.string   :kind,              null: false
+      t.datetime :last_heartbeat_at, null: false
+      t.bigint   :supervisor_id
+      t.integer  :pid,               null: false
+      t.string   :hostname
+      t.text     :metadata
+      t.datetime :created_at,        null: false
+      t.string   :name,              null: false
+
+      t.index :last_heartbeat_at, name: "index_solid_queue_processes_on_last_heartbeat_at"
+      t.index [ :name, :supervisor_id ], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+      t.index :supervisor_id, name: "index_solid_queue_processes_on_supervisor_id"
+    end
+
+    create_table :solid_queue_ready_executions do |t|
+      t.bigint   :job_id,     null: false
+      t.string   :queue_name, null: false
+      t.integer  :priority,   default: 0, null: false
+      t.datetime :created_at, null: false
+
+      t.index :job_id, name: "index_solid_queue_ready_executions_on_job_id", unique: true
+      t.index [ :priority, :job_id ], name: "index_solid_queue_poll_all"
+      t.index [ :queue_name, :priority, :job_id ], name: "index_solid_queue_poll_by_queue"
+    end
+
+    create_table :solid_queue_recurring_executions do |t|
+      t.bigint   :job_id,     null: false
+      t.string   :task_key,   null: false
+      t.datetime :run_at,     null: false
+      t.datetime :created_at, null: false
+
+      t.index :job_id, name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+      t.index [ :task_key, :run_at ], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+    end
+
+    create_table :solid_queue_recurring_tasks do |t|
+      t.string  :key,        null: false
+      t.string  :schedule,   null: false
+      t.string  :command,    limit: 2048
+      t.string  :class_name
+      t.text    :arguments
+      t.string  :queue_name
+      t.integer :priority,   default: 0
+      t.boolean :static,     default: true, null: false
+      t.text    :description
+      t.timestamps null: false
+
+      t.index :key,    name: "index_solid_queue_recurring_tasks_on_key", unique: true
+      t.index :static, name: "index_solid_queue_recurring_tasks_on_static"
+    end
+
+    create_table :solid_queue_scheduled_executions do |t|
+      t.bigint   :job_id,       null: false
+      t.string   :queue_name,   null: false
+      t.integer  :priority,     default: 0, null: false
+      t.datetime :scheduled_at, null: false
+      t.datetime :created_at,   null: false
+
+      t.index :job_id, name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+      t.index [ :scheduled_at, :priority, :job_id ], name: "index_solid_queue_dispatch_all"
+    end
+
+    create_table :solid_queue_semaphores do |t|
+      t.string   :key,        null: false
+      t.integer  :value,      default: 1, null: false
+      t.datetime :expires_at, null: false
+      t.timestamps null: false
+
+      t.index :expires_at, name: "index_solid_queue_semaphores_on_expires_at"
+      t.index [ :key, :value ], name: "index_solid_queue_semaphores_on_key_and_value"
+      t.index :key, name: "index_solid_queue_semaphores_on_key", unique: true
+    end
+
+    add_foreign_key :solid_queue_blocked_executions,   :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_claimed_executions,   :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_failed_executions,    :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_ready_executions,     :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_recurring_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_scheduled_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `db/queue_migrate/20260610000001_create_solid_queue_tables.rb` containing all Solid Queue table definitions
- The `queue:` top-level key in `database.yml` is treated by Rails as a standalone environment, not a secondary database — so `db:migrate` never targeted `storage/queue.sqlite3` and the tables were never created
- All schema loading attempts (`db:prepare`, `db:schema:load:queue`, `DatabaseTasks.load_schema`) silently failed for the same reason

## After deploying

SSH into the server and run:

\`\`\`
RAILS_ENV=queue bin/rails db:migrate
\`\`\`

This targets the queue environment directly, migrates `storage/queue.sqlite3`, and creates all `solid_queue_*` tables. The article update 500 error will be resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)