### PR TITLE
chore: add save/cancel buttons to top of article form

### DIFF
--- a/app/views/dashboard/articles/_form.html.erb
+++ b/app/views/dashboard/articles/_form.html.erb
@@ -1,6 +1,15 @@
 <%= form_with model: [:dashboard, article], html: { multipart: true } do |form| %>
   <%= render "shared/form_errors", object: article %>
 
+  <div class="d-flex gap-2 mb-4">
+    <%= form.submit class: "btn btn-primary" %>
+    <% if article.persisted? %>
+      <%= link_to "Cancel", dashboard_article_path(article), class: "btn btn-link" %>
+    <% else %>
+      <%= link_to "Cancel", dashboard_articles_path, class: "btn btn-link" %>
+    <% end %>
+  </div>
+
   <div class="mb-3">
     <%= form.label :title, class: "form-label" %>
     <%= form.text_field :title, class: "form-control" %>

--- a/spec/system/dashboard_article_edit_spec.rb
+++ b/spec/system/dashboard_article_edit_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Dashboard article edit", type: :system do
 
     it "saves changes and shows a success notice" do
       fill_in "Title", with: "#{@article.title} edited"
-      click_button "Update Article"
+      first(:button, "Update Article").click
       expect(page).to have_text("Article was successfully updated.")
     end
   end

--- a/spec/system/dashboard_article_new_spec.rb
+++ b/spec/system/dashboard_article_new_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Dashboard article new", type: :system do
     end
 
     it "shows validation errors when submitted without a title" do
-      click_button "Create Article"
+      first(:button, "Create Article").click
       expect(page).to have_text("Title can't be blank")
     end
   end


### PR DESCRIPTION
## Summary

- Duplicates the save/cancel button row to the top of the article form so admins don't need to scroll to the bottom after editing fields near the top.
- Fixes two system specs that used `click_button` (which raises `Ambiguous` when two matching buttons exist) — updated to `first(:button, "...")` using Capybara's `:button` selector which matches both `<button>` and `<input type="submit">`.

## Test plan

- [ ] `/admin/articles/new` — "Create Article" button appears both at the top and bottom of the form
- [ ] `/admin/articles/:id/edit` — "Update Article" button appears both at the top and bottom; Cancel links work from both positions
- [ ] `bin/rspec` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)