### PR TITLE
chore: OG image fixes, Solid Queue dev setup, and article card image improvements

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: bin/rails server -p 3000
 css: bin/rails dartsass:watch
+worker: bin/rails solid_queue:start

--- a/app/assets/stylesheets/_article_card.scss
+++ b/app/assets/stylesheets/_article_card.scss
@@ -19,6 +19,7 @@
     border-radius: 5px;
     display: block;
     overflow: hidden;
+    height: 220px;
 
     @media (max-width: 600px) {
       display: none;

--- a/app/models/concerns/article/og_image_generation.rb
+++ b/app/models/concerns/article/og_image_generation.rb
@@ -2,19 +2,20 @@ module Article::OgImageGeneration
   extend ActiveSupport::Concern
 
   included do
+    before_save :capture_image_change
     after_commit :enqueue_og_image_generation, if: :should_regenerate_og_image?
   end
 
   private
 
+  def capture_image_change
+    @image_changed = attachment_changes["image"].present?
+  end
+
   def should_regenerate_og_image?
     return false unless is_published? && image.attached?
 
-    saved_change_to_title? || !og_image.attached? || image_newer_than_og_card?
-  end
-
-  def image_newer_than_og_card?
-    image.blob.created_at > og_image.blob.created_at
+    saved_change_to_title? || !og_image.attached? || @image_changed
   end
 
   def enqueue_og_image_generation

--- a/app/services/og_image_service.rb
+++ b/app/services/og_image_service.rb
@@ -1,9 +1,11 @@
 class OgImageService
-  OG_WIDTH        = 1200
-  OG_HEIGHT       = 630
-  OVERLAY_OPACITY = 0.72
-  TEXT_MAX_WIDTH  = 1100
-  FONT_SPEC       = "DejaVu Sans Bold 52"
+  OG_WIDTH       = 1200
+  OG_HEIGHT      = 630
+  IMAGE_HEIGHT   = 420  # top ~2/3: photo area, fully visible
+  BAND_HEIGHT    = OG_HEIGHT - IMAGE_HEIGHT  # bottom ~1/3: solid text area
+  BAND_COLOR     = [24.0, 24.0, 24.0].freeze
+  TEXT_MAX_WIDTH = 1100
+  FONT_SPEC      = "DejaVu Sans Bold 48"
 
   Result = Data.define(:bytes, :content_type)
 
@@ -17,28 +19,22 @@ class OgImageService
   end
 
   def call
-    base   = Vips::Image.thumbnail_buffer(@image_bytes, OG_WIDTH,
+    photo  = Vips::Image.thumbnail_buffer(@image_bytes, OG_WIDTH,
                height: OG_HEIGHT, crop: :centre, size: :both)
-    base   = base.extract_band(0, n: 3) if base.bands > 3
-    canvas = apply_dark_overlay(base)
+    photo  = photo.extract_band(0, n: 3) if photo.bands > 3
+
+    # Replace bottom BAND_HEIGHT pixels with a solid dark band (full opacity)
+    dark_band = photo.crop(0, IMAGE_HEIGHT, OG_WIDTH, BAND_HEIGHT)
+                     .linear([0.0, 0.0, 0.0], BAND_COLOR)
+                     .bandjoin_const([255])
+
+    canvas = photo.composite2(dark_band, :over, x: 0, y: IMAGE_HEIGHT)
     canvas = composite_text(canvas, @title) unless @title.empty?
+
     Result.new(bytes: canvas.write_to_buffer(".jpg[Q=88]"), content_type: "image/jpeg")
   end
 
   private
-
-  def apply_dark_overlay(img)
-    band_h = (OG_HEIGHT * 0.45).round
-    alpha  = (OVERLAY_OPACITY * 255).round
-    y_pos  = OG_HEIGHT - band_h
-
-    black_strip = img
-      .crop(0, y_pos, OG_WIDTH, band_h)
-      .linear([0.0, 0.0, 0.0], [0.0, 0.0, 0.0])
-      .bandjoin_const([alpha])
-
-    img.composite2(black_strip, :over, x: 0, y: y_pos)
-  end
 
   def composite_text(img, title)
     text_mask = Vips::Image.text(
@@ -54,9 +50,9 @@ class OgImageService
       .copy(interpretation: :srgb)
       .bandjoin(text_mask)
 
-    margin = 48
     x = ((OG_WIDTH - text_rgba.width) / 2).clamp(50, OG_WIDTH)
-    y = [OG_HEIGHT - text_rgba.height - margin, 10].max
+    # Vertically center text within the dark band
+    y = IMAGE_HEIGHT + [(BAND_HEIGHT - text_rgba.height) / 2, 8].max
 
     img.composite2(text_rgba, :over, x: x, y: y)
   end

--- a/app/services/og_image_service.rb
+++ b/app/services/og_image_service.rb
@@ -20,7 +20,7 @@ class OgImageService
 
   def call
     photo  = Vips::Image.thumbnail_buffer(@image_bytes, OG_WIDTH,
-               height: OG_HEIGHT, crop: :centre, size: :both)
+               height: OG_HEIGHT, crop: :attention, size: :both)
     photo  = photo.extract_band(0, n: 3) if photo.bands > 3
 
     # Replace bottom BAND_HEIGHT pixels with a solid dark band (full opacity)

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -5,7 +5,7 @@
     <div class="article-card__banner">
       <% if article.image.attached? %>
         <%= link_to article_path(article), class: "anchor-card" do %>
-          <%= image_tag url_for(article.image.variant(resize_to_limit: [600, 400])),
+          <%= image_tag url_for(article.image.variant(resize_to_fill: [600, 400, { crop: :attention }])),
                 class: "article-card__img",
                 alt: article.title,
                 loading: "lazy" %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,6 +32,10 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
+  # Use Solid Queue for background jobs (mirrors production).
+  config.active_job.queue_adapter = :solid_queue
+  config.solid_queue.connects_to = { database: { writing: :queue } }
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -168,5 +168,14 @@ RSpec.describe Article, type: :model do
         article.update!(title: "No Image #{SecureRandom.hex(4)}")
       }.not_to have_enqueued_job(OgImageGenerationJob)
     end
+
+    it "enqueues the job when the cover image is replaced on a published article" do
+      article = create(:article, :published)
+      new_image = { io: StringIO.new("y" * 1024), filename: "new.png", content_type: "image/png" }
+
+      expect {
+        article.update!(image: new_image)
+      }.to have_enqueued_job(OgImageGenerationJob).with(article.id)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- **Fix OG image not regenerating on cover image change** — the `after_commit` callback was reading a stale AR association cache for `image.blob`; replaced the blob-timestamp comparison with a `before_save` flag that captures `attachment_changes["image"]` reliably. Added a spec covering the cover-image-replaced → job-enqueued path.
- **Redesign OG image layout** — replaced the semi-transparent overlay approach with a two-zone layout: photo fills the top 420px (fully visible, no overlay), solid dark band (`#181818`) fills the bottom 210px with the title centered in it.
- **Use attention crop for OG images** — switched from `crop: :centre` to `crop: :attention` so libvips uses a saliency model to preserve the most important region of the cover photo rather than mechanically center-cropping.
- **Wire Solid Queue in development** — added `queue_adapter: :solid_queue` and `connects_to` to `development.rb`; added `worker: bin/rails solid_queue:start` to `Procfile.dev` so dev mirrors production.
- **Uniform article card image heights** — added `height: 220px` to `.article-card__banner` so all card thumbnails render at a consistent size.
- **Attention crop for card thumbnails** — changed variant from `resize_to_limit: [600, 400]` to `resize_to_fill: [600, 400, { crop: :attention }]` so cover images are intelligently pre-cropped server-side before display.

## Test plan

- [ ] Edit a published article, swap the cover image, save — confirm OG card regenerates automatically (Solid Queue worker must be running via `bin/dev`)
- [ ] Manually hit "Regenerate" on a dashboard article show page — confirm OG card updates with new two-zone layout (photo top, title band bottom)
- [ ] Check OG image on a cover with top-heavy content — confirm it is no longer cut off
- [ ] Visit `/articles` — confirm all card thumbnails are the same height and cover images show their most relevant content
- [ ] `bin/rspec` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)