### PR TITLE
fix: CSP nonce empty on first request, sort/pagination URL updates

### DIFF
--- a/app/views/dashboard/articles/index.html.erb
+++ b/app/views/dashboard/articles/index.html.erb
@@ -23,10 +23,10 @@
       <table class="table table-hover align-middle mb-0">
         <thead class="table-dark">
           <tr>
-            <th><%= link_to "Title#{sort_indicator(:title)}".html_safe, dashboard_articles_path(sort: :title, direction: sort_direction(:title), q: @query), class: "text-decoration-none text-white fw-semibold" %></th>
+            <th><%= link_to "Title#{sort_indicator(:title)}".html_safe, dashboard_articles_path(sort: :title, direction: sort_direction(:title), q: @query), class: "text-decoration-none text-white fw-semibold", data: { turbo_action: "advance" } %></th>
             <th>Tags</th>
-            <th><%= link_to "Status#{sort_indicator(:status)}".html_safe, dashboard_articles_path(sort: :status, direction: sort_direction(:status), q: @query), class: "text-decoration-none text-white fw-semibold" %></th>
-            <th><%= link_to "Date#{sort_indicator(:date)}".html_safe, dashboard_articles_path(sort: :date, direction: sort_direction(:date), q: @query), class: "text-decoration-none text-white fw-semibold" %></th>
+            <th><%= link_to "Status#{sort_indicator(:status)}".html_safe, dashboard_articles_path(sort: :status, direction: sort_direction(:status), q: @query), class: "text-decoration-none text-white fw-semibold", data: { turbo_action: "advance" } %></th>
+            <th><%= link_to "Date#{sort_indicator(:date)}".html_safe, dashboard_articles_path(sort: :date, direction: sort_direction(:date), q: @query), class: "text-decoration-none text-white fw-semibold", data: { turbo_action: "advance" } %></th>
             <th class="text-end">Actions</th>
           </tr>
         </thead>
@@ -70,7 +70,7 @@
 
   <% if @pagy.pages > 1 %>
     <div class="mt-3 d-flex justify-content-center">
-      <%== @pagy.series_nav(:bootstrap) %>
+      <%== @pagy.series_nav(:bootstrap, anchor_string: 'data-turbo-action="advance"') %>
     </div>
   <% end %>
 <% end %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -40,11 +40,11 @@ Rails.application.configure do
     policy.style_src   :self, :https, :unsafe_inline
   end
 
-  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-  # Uses the session id so the nonce is stable for the request
-  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  # Generate a cryptographically random nonce per request.
+  # Using session.id here would produce an empty nonce on the first request (no cookie yet).
+  config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
   # Nonces for scripts only; style-src uses unsafe-inline which nonces would override
-  config.content_security_policy_nonce_directives = %w(script-src)
+  config.content_security_policy_nonce_directives = %w[script-src]
   # Automatically add nonce attributes to Rails-provided tag helpers
   config.content_security_policy_nonce_auto = true
 end


### PR DESCRIPTION
## Summary

- **CSP nonce fix**: `request.session.id` returns `nil` on the very first page load (no session cookie yet), so `.to_s` produced an empty string — causing the CSP header to advertise `'nonce-'` (empty). Every inline script (dark mode theme init, JSON-LD) was blocked until a hard refresh created a session. Replaced with `SecureRandom.base64(16)` which is the correct approach for per-request CSP nonces.
- **Sort/pagination URL fix**: Sort column links and pagy pagination links inside the `turbo_frame_tag "articles-table"` were not updating the browser URL on click (Turbo frame navigation doesn't push history by default). Added `data-turbo-action="advance"` to sort links and `anchor_string: 'data-turbo-action="advance"'` to the pagy `series_nav` call so Turbo pushes the new URL into history.

## Test plan

- [ ] Hard-reload the production site on a fresh browser session — dark mode toggle should work immediately, no CSP errors in the console
- [ ] Dark mode preference should be remembered across page loads
- [ ] On the dashboard articles index, clicking Title/Status/Date sort headers should update the URL (`?sort=title`, etc.)
- [ ] Clicking a pagination number should update the URL (`?page=2`)
- [ ] All 360 specs pass (`bin/rspec`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)