### PR TITLE
feat: Searchable select for related article on project form

### DIFF
--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -1,7 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="tom-select"
+// data-tom-select-mode-value: "tags" (default) or "search"
 export default class extends Controller {
+  static values = { mode: { type: String, default: "tags" } }
+
   connect() {
     // Skip if already initialized (prevents double initialization)
     if (this.element.tomselect) {
@@ -23,6 +26,23 @@ export default class extends Controller {
   }
 
   setupTomSelect() {
+    if (this.modeValue === "search") {
+      this.tomSelect = new TomSelect(this.element, {
+        maxItems: 1,
+        create: false,
+        allowEmptyOption: true,
+        placeholder: 'Search articles...',
+        onInitialize: function() {
+          const label = document.querySelector(`label[for="${this.input.id}"]`)
+          if (label) {
+            if (!label.id) label.id = `label-${this.input.id}`
+            this.control_input.setAttribute('aria-labelledby', label.id)
+          }
+        }
+      })
+      return
+    }
+
     // Get CSRF token for AJAX requests
     const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
 

--- a/app/views/dashboard/projects/_form.html.erb
+++ b/app/views/dashboard/projects/_form.html.erb
@@ -84,7 +84,8 @@
       <%= f.collection_select :article_id,
             @articles, :id, :title,
             { include_blank: "— none —" },
-            class: "form-select" %>
+            class: "form-select",
+            data: { controller: "tom-select", "tom-select-mode-value": "search" } %>
       <div class="form-text">When set, the project title links to this article instead of the external URL.</div>
     </div>
 


### PR DESCRIPTION
## Summary

- Extends the `tom-select` Stimulus controller with a `mode` value (`"tags"` or `"search"`) so it can serve both use cases
- `"search"` mode: single-select, no item creation, blank option preserved for clearing the selection
- Wires up the related article field on the dashboard project form to use `mode="search"`

## Test plan

- [ ] Open dashboard project new/edit form — related article field renders as a searchable dropdown
- [ ] Type to filter articles by title
- [ ] Select an article and save — association persists correctly
- [ ] Clear selection (choose "— none —") and save — association clears correctly
- [ ] Verify article form tag select is unaffected (still multi-select with create)

🤖 Generated with [Claude Code](https://claude.com/claude-code)